### PR TITLE
Fix missing DI registration for background manager

### DIFF
--- a/MagentaTV/Extensions/BackgroundServiceExtensions.cs
+++ b/MagentaTV/Extensions/BackgroundServiceExtensions.cs
@@ -18,6 +18,7 @@ namespace MagentaTV.Extensions
             // Register core services
             services.AddSingleton<IEventBus, EventBus>();
             services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
+            services.AddSingleton<IBackgroundServiceManager, BackgroundServiceManager>();
 
             // Register event handlers
             services.AddSingleton<BackgroundEventHandlers>();


### PR DESCRIPTION
## Summary
- register `IBackgroundServiceManager` with `BackgroundServiceManager`

## Testing
- `dotnet build` *(fails: current SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684193f464d88326bc2b339c21a858f0