### PR TITLE
Implement refresh logic and incident handling

### DIFF
--- a/MagentaTV/Application/EventHandlers/UserLoggedOutEventHandler.cs
+++ b/MagentaTV/Application/EventHandlers/UserLoggedOutEventHandler.cs
@@ -387,17 +387,21 @@ namespace MagentaTV.Application.EventHandlers
 
                     try
                     {
-                        // Zde by byla implementace security incident processing
-                        // - Email alerts
-                        // - External security system notifications
-                        // - Temporary account restrictions
-                        // - Threat intelligence feeds
+                        var incidentEntry = new
+                        {
+                            Username = notification.Username,
+                            SessionId = notification.SessionId,
+                            Reason = notification.Reason,
+                            Timestamp = notification.Timestamp,
+                            ProcessedAt = DateTime.UtcNow
+                        };
+
+                        var file = Path.Combine("data", "security", $"incidents_{DateTime.UtcNow:yyyyMM}.log");
+                        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+                        await File.AppendAllTextAsync(file, System.Text.Json.JsonSerializer.Serialize(incidentEntry) + Environment.NewLine, ct);
 
                         logger.LogWarning("Security incident processed for user {Username}: session revocation",
                             notification.Username);
-
-                        // TODO: Implement actual security incident handling
-                        // await securityService.ProcessIncidentAsync(incident);
                     }
                     catch (Exception ex)
                     {

--- a/MagentaTV/Services/Background/Services/TokenRefreshService.cs
+++ b/MagentaTV/Services/Background/Services/TokenRefreshService.cs
@@ -64,9 +64,16 @@ namespace MagentaTV.Services.Background.Services
 
         private async Task<TokenData?> RefreshTokensAsync(IMagenta service, TokenData currentTokens)
         {
-            // Implementace refresh logiky
-            // TODO: Přidat refresh endpoint do Magenta service
-            return null;
+            try
+            {
+                var refreshed = await service.RefreshTokensAsync(currentTokens);
+                return refreshed;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Token refresh request failed");
+                return null;
+            }
         }
     }
 }

--- a/MagentaTV/Services/IMagenta.cs
+++ b/MagentaTV/Services/IMagenta.cs
@@ -1,4 +1,5 @@
 ﻿using MagentaTV.Models;
+using MagentaTV.Services.TokenStorage;
 
 namespace MagentaTV.Services;
 
@@ -43,4 +44,9 @@ public interface IMagenta
     /// Generování XMLTV
     /// </summary>
     string GenerateXmlTv(List<EpgItemDto> epg, int channelId);
+
+    /// <summary>
+    /// Obnoví access token pomocí refresh tokenu
+    /// </summary>
+    Task<TokenData?> RefreshTokensAsync(TokenData currentTokens);
 }


### PR DESCRIPTION
## Summary
- add `RefreshTokensAsync` method to `IMagenta`
- implement refresh token functionality in `Magenta` service
- refresh session tokens via `Magenta` in command handler
- invoke refresh from background service
- log security incidents to file

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf0e25448326aca725e9092dcfa6