### PR TITLE
Add SignalR hub support

### DIFF
--- a/MagentaTV/Hubs/NotificationHub.cs
+++ b/MagentaTV/Hubs/NotificationHub.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace MagentaTV.Hubs
+{
+    public class NotificationHub : Hub
+    {
+        public async Task SendMessage(string user, string message) =>
+            await Clients.All.SendAsync("ReceiveMessage", user, message);
+    }
+}

--- a/MagentaTV/MagentaTV.csproj
+++ b/MagentaTV/MagentaTV.csproj
@@ -6,23 +6,24 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-		<PackageReference Include="FFMpegCore" Version="5.2.0" />
-		<PackageReference Include="FluentValidation" Version="12.0.0" />
-		<PackageReference Include="MediatR" Version="12.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-		<PackageReference Include="Polly" Version="8.5.2" />
-		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
-		<PackageReference Include="System.Threading.RateLimiting" Version="9.0.5" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+                <PackageReference Include="FFMpegCore" Version="5.2.0" />
+                <PackageReference Include="FluentValidation" Version="12.0.0" />
+                <PackageReference Include="MediatR" Version="12.5.0" />
+                <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+                <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+                <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.5" />
+                <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
+                <PackageReference Include="Polly" Version="8.5.2" />
+                <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+                <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.4" />
+                <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
+                <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
+                <PackageReference Include="System.Threading.RateLimiting" Version="9.0.5" />
+                <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<Folder Include="data\" />

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -12,6 +12,7 @@ using MagentaTV.Extensions;
 using MagentaTV.Services.Background.Services;
 using MediatR;
 using MagentaTV.Services.Background;
+using MagentaTV.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -33,6 +34,7 @@ builder.Services.AddTransient<INotificationHandler<UserLoggedOutEvent>, UserLogg
 
 // Add services to the container
 builder.Services.AddControllers();
+builder.Services.AddSignalR();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
@@ -189,6 +191,7 @@ app.UseRateLimiter();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapHub<NotificationHub>("/hubs/notifications");
 
 // Legacy route redirects for removed session endpoints
 app.MapPost("/sessions/create", () => Results.Redirect("/auth/login", permanent: true, preserveMethod: true));


### PR DESCRIPTION
## Summary
- add framework reference for Microsoft.AspNetCore.App
- implement NotificationHub for SignalR broadcast
- register SignalR services and map the hub endpoint

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bcdb7c648326acdef59e26722481