### PR TITLE
Add configurable network service

### DIFF
--- a/MagentaTV/Configuration/NetworkOptions.cs
+++ b/MagentaTV/Configuration/NetworkOptions.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MagentaTV.Configuration;
+
+public class NetworkOptions
+{
+    public const string SectionName = "Network";
+
+    [RegularExpression(@"^\d{1,3}(\.\d{1,3}){3}$")]
+    public string IpAddress { get; set; } = "127.0.0.1";
+
+    [RegularExpression(@"^\d{1,3}(\.\d{1,3}){3}$")]
+    public string SubnetMask { get; set; } = "255.255.255.0";
+
+    [RegularExpression(@"^\d{1,3}(\.\d{1,3}){3}$")]
+    public string Gateway { get; set; } = "127.0.0.1";
+
+    public string[] DnsServers { get; set; } = new[] { "8.8.8.8", "8.8.4.4" };
+
+    public string? ProxyAddress { get; set; }
+
+    [Range(0, 65535)]
+    public int ProxyPort { get; set; }
+
+    [Range(1, 1000)]
+    public int MaxConnectionsPerServer { get; set; } = 20;
+
+    [Range(1, 600)]
+    public int ConnectionTimeoutSeconds { get; set; } = 30;
+
+    public bool EnableSsl { get; set; } = true;
+
+    public bool ValidateServerCertificate { get; set; } = true;
+}

--- a/MagentaTV/MagentaTV.csproj
+++ b/MagentaTV/MagentaTV.csproj
@@ -27,9 +27,10 @@
 	<ItemGroup>
 		<Folder Include="data\" />
 		<Folder Include="logs\" />
-		<Folder Include="Models\Session\" />
-		<Folder Include="Services\Session\" />
-	</ItemGroup>
+                <Folder Include="Models\Session\" />
+                <Folder Include="Services\Session\" />
+                <Folder Include="Services\Network\" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<None Update="dev_id.txt">

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -13,6 +13,7 @@ using MagentaTV.Services.Background.Services;
 using MediatR;
 using MagentaTV.Services.Background;
 using MagentaTV.Hubs;
+using MagentaTV.Services.Network;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -55,8 +56,18 @@ builder.Services.AddMediatRWithBehaviors();
 // Memory cache
 builder.Services.AddMemoryCache();
 
-// HTTP Client - simplified without Polly for now
-builder.Services.AddHttpClient<IMagenta, Magenta>();
+// Network configuration and service
+builder.Services.Configure<NetworkOptions>(
+    builder.Configuration.GetSection(NetworkOptions.SectionName));
+builder.Services.AddSingleton<INetworkService, NetworkService>();
+
+// HTTP Client configured via NetworkService
+builder.Services.AddHttpClient<IMagenta, Magenta>()
+    .ConfigurePrimaryHttpMessageHandler(sp =>
+    {
+        var network = sp.GetRequiredService<INetworkService>();
+        return network.CreateHttpMessageHandler();
+    });
 
 // Configuration options with validation
 builder.Services.Configure<MagentaTVOptions>(

--- a/MagentaTV/Services/Network/INetworkService.cs
+++ b/MagentaTV/Services/Network/INetworkService.cs
@@ -1,0 +1,10 @@
+using System.Net.Http;
+using MagentaTV.Configuration;
+
+namespace MagentaTV.Services.Network;
+
+public interface INetworkService
+{
+    HttpMessageHandler CreateHttpMessageHandler();
+    NetworkOptions Options { get; }
+}

--- a/MagentaTV/Services/Network/NetworkService.cs
+++ b/MagentaTV/Services/Network/NetworkService.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http;
+using Microsoft.Extensions.Options;
+using MagentaTV.Configuration;
+
+namespace MagentaTV.Services.Network;
+
+public class NetworkService : INetworkService
+{
+    private readonly NetworkOptions _options;
+    private readonly ILogger<NetworkService> _logger;
+
+    public NetworkService(IOptions<NetworkOptions> options, ILogger<NetworkService> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public NetworkOptions Options => _options;
+
+    public HttpMessageHandler CreateHttpMessageHandler()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            MaxConnectionsPerServer = _options.MaxConnectionsPerServer,
+            ConnectTimeout = TimeSpan.FromSeconds(_options.ConnectionTimeoutSeconds)
+        };
+
+        if (!string.IsNullOrEmpty(_options.ProxyAddress))
+        {
+            handler.Proxy = new WebProxy(_options.ProxyAddress, _options.ProxyPort);
+            handler.UseProxy = true;
+            _logger.LogInformation("Using proxy {Proxy}:{Port}", _options.ProxyAddress, _options.ProxyPort);
+        }
+
+        if (!_options.EnableSsl)
+        {
+            handler.SslOptions.EnabledSslProtocols = System.Security.Authentication.SslProtocols.None;
+        }
+        else if (!_options.ValidateServerCertificate)
+        {
+            handler.SslOptions.RemoteCertificateValidationCallback = (_,_,_,_) => true;
+        }
+
+        return handler;
+    }
+}

--- a/MagentaTV/appsettings.Development.json
+++ b/MagentaTV/appsettings.Development.json
@@ -85,6 +85,19 @@
     "StreamUrlExpirationMinutes": 1
   },
 
+  "Network": {
+    "IpAddress": "192.168.1.50",
+    "SubnetMask": "255.255.255.0",
+    "Gateway": "192.168.1.1",
+    "DnsServers": [ "8.8.8.8", "8.8.4.4" ],
+    "ProxyAddress": "",
+    "ProxyPort": 0,
+    "MaxConnectionsPerServer": 10,
+    "ConnectionTimeoutSeconds": 60,
+    "EnableSsl": true,
+    "ValidateServerCertificate": true
+  },
+
   "HealthChecks": {
     "Enabled": true,
     "DetailedErrors": true,

--- a/MagentaTV/appsettings.json
+++ b/MagentaTV/appsettings.json
@@ -89,6 +89,19 @@
     "StreamUrlExpirationMinutes": 5
   },
 
+  "Network": {
+    "IpAddress": "192.168.1.100",
+    "SubnetMask": "255.255.255.0",
+    "Gateway": "192.168.1.1",
+    "DnsServers": [ "8.8.8.8", "8.8.4.4" ],
+    "ProxyAddress": "",
+    "ProxyPort": 0,
+    "MaxConnectionsPerServer": 20,
+    "ConnectionTimeoutSeconds": 30,
+    "EnableSsl": true,
+    "ValidateServerCertificate": true
+  },
+
   "Api": {
     "Title": "MagentaTV API",
     "Version": "v1",

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -26,6 +26,19 @@
     "StreamUrlExpirationMinutes": 10
   },
 
+  "Network": {
+    "IpAddress": "192.168.1.200",
+    "SubnetMask": "255.255.255.0",
+    "Gateway": "192.168.1.1",
+    "DnsServers": [ "8.8.8.8", "8.8.4.4" ],
+    "ProxyAddress": "",
+    "ProxyPort": 0,
+    "MaxConnectionsPerServer": 50,
+    "ConnectionTimeoutSeconds": 20,
+    "EnableSsl": true,
+    "ValidateServerCertificate": true
+  },
+
   "HealthChecks": {
     "DetailedErrors": false,
     "TimeoutSeconds": 5


### PR DESCRIPTION
## Summary
- add `NetworkOptions` configuration
- implement `NetworkService` for network-level settings
- register network service and configure `HttpClient`
- expose network config in all appsettings files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bf9225ec832687ae5e3b1ac7bd35