### PR TITLE
Implement Telemetry background service

### DIFF
--- a/MagentaTV/Configuration/TelemetryOptions.cs
+++ b/MagentaTV/Configuration/TelemetryOptions.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MagentaTV.Configuration;
+
+public class TelemetryOptions
+{
+    public const string SectionName = "Telemetry";
+
+    [Range(1, 1440)]
+    public int IntervalMinutes { get; set; } = 5;
+
+    public string LogFilePath { get; set; } = "logs/telemetry.log";
+}

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -22,11 +22,14 @@ builder.Services.AddBackgroundServices(builder.Configuration);
 
 builder.Services.AddBackgroundService<TokenRefreshService>();
 builder.Services.AddBackgroundService<SessionCleanupService>();
-builder.Services.AddBackgroundService<CacheWarmingService>(); 
+builder.Services.AddBackgroundService<CacheWarmingService>();
+builder.Services.AddBackgroundService<TelemetryService>();
 
 
 builder.Services.AddSingleton<ICacheWarmingService>(provider =>
     provider.GetRequiredService<CacheWarmingService>());
+builder.Services.AddSingleton<ITelemetryService>(provider =>
+    provider.GetRequiredService<TelemetryService>());
 
 // MediatR Event Handlers
 builder.Services.AddTransient<INotificationHandler<UserLoggedInEvent>, UserLoggedInEventHandler>();
@@ -82,6 +85,8 @@ builder.Services.Configure<CorsOptions>(
     builder.Configuration.GetSection(CorsOptions.SectionName));
 builder.Services.Configure<RateLimitOptions>(
     builder.Configuration.GetSection(RateLimitOptions.SectionName));
+builder.Services.Configure<TelemetryOptions>(
+    builder.Configuration.GetSection(TelemetryOptions.SectionName));
 
 // Validate configuration
 builder.Services.AddSingleton<IValidateOptions<MagentaTV.Configuration.SessionOptions>, ValidateSessionOptions>();

--- a/MagentaTV/Services/Background/Services/ITelemetryService.cs
+++ b/MagentaTV/Services/Background/Services/ITelemetryService.cs
@@ -1,0 +1,9 @@
+namespace MagentaTV.Services.Background.Services;
+
+public interface ITelemetryService
+{
+    /// <summary>
+    /// Triggers immediate telemetry collection.
+    /// </summary>
+    Task CollectAsync();
+}

--- a/MagentaTV/Services/Background/Services/TelemetryService.cs
+++ b/MagentaTV/Services/Background/Services/TelemetryService.cs
@@ -1,0 +1,77 @@
+using MagentaTV.Configuration;
+using MagentaTV.Services.Background.Core;
+using MagentaTV.Services.Background.Events;
+using MagentaTV.Services.Background;
+using MagentaTV.Services.Cache;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace MagentaTV.Services.Background.Services;
+
+public class TelemetryService : BaseBackgroundService, ITelemetryService
+{
+    private readonly TelemetryOptions _options;
+
+    public TelemetryService(
+        ILogger<TelemetryService> logger,
+        IServiceProvider serviceProvider,
+        IEventBus eventBus,
+        IOptions<TelemetryOptions> options)
+        : base(logger, serviceProvider, eventBus, "TelemetryService")
+    {
+        _options = options.Value;
+    }
+
+    public async Task CollectAsync()
+    {
+        await CollectTelemetryAsync(CancellationToken.None);
+    }
+
+    protected override async Task ExecuteServiceAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await CollectTelemetryAsync(stoppingToken);
+
+            await Task.Delay(TimeSpan.FromMinutes(_options.IntervalMinutes), stoppingToken);
+            UpdateHeartbeat();
+        }
+    }
+
+    private async Task<bool> CollectTelemetryAsync(CancellationToken stoppingToken)
+    {
+        return await ExecuteWithEventsAsync("CollectTelemetry", async () =>
+        {
+            using var scope = CreateScope();
+            var manager = scope.ServiceProvider.GetRequiredService<IBackgroundServiceManager>();
+            var cache = scope.ServiceProvider.GetRequiredService<ICacheService>();
+
+            var stats = await manager.GetStatsAsync();
+            var services = await manager.GetAllServicesInfoAsync();
+            var cacheStats = await cache.GetStatisticsAsync();
+
+            var telemetry = new
+            {
+                Timestamp = DateTime.UtcNow,
+                BackgroundStats = stats,
+                ServiceInfo = services,
+                CacheStats = cacheStats
+            };
+
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_options.LogFilePath)!);
+                var json = JsonSerializer.Serialize(telemetry);
+                await File.AppendAllTextAsync(_options.LogFilePath, json + Environment.NewLine, stoppingToken);
+                SetMetric("last_write", DateTime.UtcNow);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to write telemetry data");
+                SetMetric("write_errors", GetMetric<long>("write_errors") + 1);
+            }
+
+            return true;
+        });
+    }
+}

--- a/MagentaTV/appsettings.json
+++ b/MagentaTV/appsettings.json
@@ -114,5 +114,9 @@
     "Enabled": true,
     "DetailedErrors": false,
     "TimeoutSeconds": 10
+  },
+  "Telemetry": {
+    "IntervalMinutes": 5,
+    "LogFilePath": "logs/telemetry.log"
   }
 }

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -70,5 +70,9 @@
     "ChannelsExpirationMinutes": 90,
     "EpgExpirationMinutes": 45,
     "StreamUrlExpirationMinutes": 8
+  },
+  "Telemetry": {
+    "IntervalMinutes": 5,
+    "LogFilePath": "logs/telemetry.log"
   }
 }


### PR DESCRIPTION
## Summary
- add `TelemetryService` background service to collect service and cache stats
- introduce `TelemetryOptions` for interval and log path
- register telemetry service and options in `Program.cs`
- configure telemetry settings in `appsettings.json` and `appsettings.Production.json`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c9a8dbc08326a0542a909dfae3ef