### PR TITLE
Fix missing cache service registration

### DIFF
--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddMediatRWithBehaviors();
 
 // Memory cache
 builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<ICacheService, CacheService>();
 
 // Network configuration and service
 builder.Services.Configure<NetworkOptions>(


### PR DESCRIPTION
## Summary
- register `CacheService` implementation of `ICacheService` in the DI container

## Testing
- `dotnet test MagentaTV.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cbe25d5c8326a1f19f994684753f