### PR TITLE
Split Magenta service into domain services

### DIFF
--- a/MagentaTV/Application/Commands/QueueBackgroundWorkCommandHandler.cs
+++ b/MagentaTV/Application/Commands/QueueBackgroundWorkCommandHandler.cs
@@ -1,7 +1,8 @@
 ﻿using MagentaTV.Models;
 using MagentaTV.Services.Background.Core;
 using MagentaTV.Services.Background;
-using MagentaTV.Services;
+using MagentaTV.Services.Channels;
+using MagentaTV.Services.Epg;
 using MediatR;
 
 namespace MagentaTV.Application.Commands
@@ -41,15 +42,15 @@ namespace MagentaTV.Application.Commands
             {
                 "CACHE_REFRESH" => async (provider, ct) =>
                 {
-                    var magenta = provider.GetRequiredService<IMagenta>();
-                    await magenta.GetChannelsAsync();
+                    var channelService = provider.GetRequiredService<IChannelService>();
+                    await channelService.GetChannelsAsync();
                 }
                 ,
                 "EPG_PRELOAD" => async (provider, ct) =>
                 {
-                    var magenta = provider.GetRequiredService<IMagenta>();
+                    var epgService = provider.GetRequiredService<IEpgService>();
                     var channelId = (int)parameters["channelId"];
-                    await magenta.GetEpgAsync(channelId);
+                    await epgService.GetEpgAsync(channelId);
                 }
                 ,
                 _ => (provider, ct) => Task.CompletedTask

--- a/MagentaTV/Application/Queries/GenerateEpgXmlQueryHandler.cs
+++ b/MagentaTV/Application/Queries/GenerateEpgXmlQueryHandler.cs
@@ -1,16 +1,16 @@
-﻿using MagentaTV.Services;
+using MagentaTV.Services.Epg;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
 {
     public class GenerateEpgXmlQueryHandler : IRequestHandler<GenerateEpgXmlQuery, string>
     {
-        private readonly IMagenta _magentaService;
+        private readonly IEpgService _epgService;
         private readonly ILogger<GenerateEpgXmlQueryHandler> _logger;
 
-        public GenerateEpgXmlQueryHandler(IMagenta magentaService, ILogger<GenerateEpgXmlQueryHandler> logger)
+        public GenerateEpgXmlQueryHandler(IEpgService epgService, ILogger<GenerateEpgXmlQueryHandler> logger)
         {
-            _magentaService = magentaService;
+            _epgService = epgService;
             _logger = logger;
         }
 
@@ -18,8 +18,8 @@ namespace MagentaTV.Application.Queries
         {
             try
             {
-                var epg = await _magentaService.GetEpgAsync(request.ChannelId);
-                return _magentaService.GenerateXmlTv(epg, request.ChannelId);
+                var epg = await _epgService.GetEpgAsync(request.ChannelId);
+                return _epgService.GenerateXmlTv(epg, request.ChannelId);
             }
             catch (Exception ex)
             {

--- a/MagentaTV/Application/Queries/GeneratePlaylistQueryHandler.cs
+++ b/MagentaTV/Application/Queries/GeneratePlaylistQueryHandler.cs
@@ -1,24 +1,24 @@
-﻿using MagentaTV.Services;
+using MagentaTV.Services.Channels;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
 {
     public class GeneratePlaylistQueryHandler : IRequestHandler<GeneratePlaylistQuery, string>
     {
-        private readonly IMagenta _magentaService;
+    private readonly IChannelService _channelService;
         private readonly ILogger<GeneratePlaylistQueryHandler> _logger;
 
-        public GeneratePlaylistQueryHandler(IMagenta magentaService, ILogger<GeneratePlaylistQueryHandler> logger)
-        {
-            _magentaService = magentaService;
-            _logger = logger;
-        }
+    public GeneratePlaylistQueryHandler(IChannelService channelService, ILogger<GeneratePlaylistQueryHandler> logger)
+    {
+        _channelService = channelService;
+        _logger = logger;
+    }
 
         public async Task<string> Handle(GeneratePlaylistQuery request, CancellationToken cancellationToken)
         {
             try
             {
-                return await _magentaService.GenerateM3UPlaylistAsync();
+                return await _channelService.GenerateM3UPlaylistAsync();
             }
             catch (Exception ex)
             {

--- a/MagentaTV/Application/Queries/GetCatchupStreamQueryHandler.cs
+++ b/MagentaTV/Application/Queries/GetCatchupStreamQueryHandler.cs
@@ -1,17 +1,17 @@
 ﻿using MagentaTV.Models;
-using MagentaTV.Services;
+using MagentaTV.Services.Stream;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
 {
     public class GetCatchupStreamQueryHandler : IRequestHandler<GetCatchupStreamQuery, ApiResponse<StreamUrlDto>>
     {
-        private readonly IMagenta _magentaService;
+        private readonly IStreamService _streamService;
         private readonly ILogger<GetCatchupStreamQueryHandler> _logger;
 
-        public GetCatchupStreamQueryHandler(IMagenta magentaService, ILogger<GetCatchupStreamQueryHandler> logger)
+        public GetCatchupStreamQueryHandler(IStreamService streamService, ILogger<GetCatchupStreamQueryHandler> logger)
         {
-            _magentaService = magentaService;
+            _streamService = streamService;
             _logger = logger;
         }
 
@@ -19,7 +19,7 @@ namespace MagentaTV.Application.Queries
         {
             try
             {
-                var url = await _magentaService.GetCatchupStreamUrlAsync(request.ScheduleId);
+                var url = await _streamService.GetCatchupStreamUrlAsync(request.ScheduleId);
                 if (string.IsNullOrEmpty(url))
                 {
                     return ApiResponse<StreamUrlDto>.ErrorResult("Catchup stream not found",

--- a/MagentaTV/Application/Queries/GetChannelsQuery.cs
+++ b/MagentaTV/Application/Queries/GetChannelsQuery.cs
@@ -1,5 +1,5 @@
 ﻿using MagentaTV.Models;
-using MagentaTV.Services;
+using MagentaTV.Services.Channels;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
@@ -11,12 +11,12 @@ namespace MagentaTV.Application.Queries
 
     public class GetChannelsQueryHandler : IRequestHandler<GetChannelsQuery, ApiResponse<List<ChannelDto>>>
     {
-        private readonly IMagenta _magentaService;
+        private readonly IChannelService _channelService;
         private readonly ILogger<GetChannelsQueryHandler> _logger;
 
-        public GetChannelsQueryHandler(IMagenta magentaService, ILogger<GetChannelsQueryHandler> logger)
+        public GetChannelsQueryHandler(IChannelService channelService, ILogger<GetChannelsQueryHandler> logger)
         {
-            _magentaService = magentaService;
+            _channelService = channelService;
             _logger = logger;
         }
 
@@ -24,7 +24,7 @@ namespace MagentaTV.Application.Queries
         {
             try
             {
-                var channels = await _magentaService.GetChannelsAsync();
+                var channels = await _channelService.GetChannelsAsync();
                 return ApiResponse<List<ChannelDto>>.SuccessResult(channels, $"Found {channels.Count} channels");
             }
             catch (Exception ex)

--- a/MagentaTV/Application/Queries/GetEpgQuery.cs
+++ b/MagentaTV/Application/Queries/GetEpgQuery.cs
@@ -1,5 +1,5 @@
 ﻿using MagentaTV.Models;
-using MagentaTV.Services;
+using MagentaTV.Services.Epg;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
@@ -14,12 +14,12 @@ namespace MagentaTV.Application.Queries
 
     public class GetEpgQueryHandler : IRequestHandler<GetEpgQuery, ApiResponse<List<EpgItemDto>>>
     {
-        private readonly IMagenta _magentaService;
+        private readonly IEpgService _epgService;
         private readonly ILogger<GetEpgQueryHandler> _logger;
 
-        public GetEpgQueryHandler(IMagenta magentaService, ILogger<GetEpgQueryHandler> logger)
+        public GetEpgQueryHandler(IEpgService epgService, ILogger<GetEpgQueryHandler> logger)
         {
-            _magentaService = magentaService;
+            _epgService = epgService;
             _logger = logger;
         }
 
@@ -27,7 +27,7 @@ namespace MagentaTV.Application.Queries
         {
             try
             {
-                var epg = await _magentaService.GetEpgAsync(request.ChannelId, request.From, request.To);
+                var epg = await _epgService.GetEpgAsync(request.ChannelId, request.From, request.To);
                 return ApiResponse<List<EpgItemDto>>.SuccessResult(epg, $"Found {epg.Count} EPG items");
             }
             catch (Exception ex)

--- a/MagentaTV/Application/Queries/GetStreamUrlQueryHandler.cs
+++ b/MagentaTV/Application/Queries/GetStreamUrlQueryHandler.cs
@@ -1,17 +1,17 @@
 ﻿using MagentaTV.Models;
-using MagentaTV.Services;
+using MagentaTV.Services.Stream;
 using MediatR;
 
 namespace MagentaTV.Application.Queries
 {
     public class GetStreamUrlQueryHandler : IRequestHandler<GetStreamUrlQuery, ApiResponse<StreamUrlDto>>
     {
-        private readonly IMagenta _magentaService;
+        private readonly IStreamService _streamService;
         private readonly ILogger<GetStreamUrlQueryHandler> _logger;
 
-        public GetStreamUrlQueryHandler(IMagenta magentaService, ILogger<GetStreamUrlQueryHandler> logger)
+        public GetStreamUrlQueryHandler(IStreamService streamService, ILogger<GetStreamUrlQueryHandler> logger)
         {
-            _magentaService = magentaService;
+            _streamService = streamService;
             _logger = logger;
         }
 
@@ -19,7 +19,7 @@ namespace MagentaTV.Application.Queries
         {
             try
             {
-                var url = await _magentaService.GetStreamUrlAsync(request.ChannelId);
+                var url = await _streamService.GetStreamUrlAsync(request.ChannelId);
                 if (string.IsNullOrEmpty(url))
                 {
                     return ApiResponse<StreamUrlDto>.ErrorResult("Stream not found",

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -1,5 +1,8 @@
 using MagentaTV.Configuration;
 using MagentaTV.Services;
+using MagentaTV.Services.Channels;
+using MagentaTV.Services.Epg;
+using MagentaTV.Services.Stream;
 using MagentaTV.Services.Session;
 using MagentaTV.Services.TokenStorage;
 using MagentaTV.Middleware;
@@ -95,6 +98,9 @@ builder.Services.AddSingleton<IValidateOptions<TokenStorageOptions>, ValidateTok
 
 // Register main services
 builder.Services.AddScoped<IMagenta, Magenta>();
+builder.Services.AddScoped<IChannelService, ChannelService>();
+builder.Services.AddScoped<IEpgService, EpgService>();
+builder.Services.AddScoped<IStreamService, StreamService>();
 
 // Token Storage - choose implementation based on environment
 if (builder.Environment.IsDevelopment())
@@ -350,12 +356,12 @@ public class SessionHealthCheck : IHealthCheck
 
 public class MagentaTVHealthCheck : IHealthCheck
 {
-    private readonly IMagenta _magentaService;
+    private readonly IChannelService _channelService;
     private readonly ILogger<MagentaTVHealthCheck> _logger;
 
-    public MagentaTVHealthCheck(IMagenta magentaService, ILogger<MagentaTVHealthCheck> logger)
+    public MagentaTVHealthCheck(IChannelService channelService, ILogger<MagentaTVHealthCheck> logger)
     {
-        _magentaService = magentaService;
+        _channelService = channelService;
         _logger = logger;
     }
 
@@ -365,7 +371,7 @@ public class MagentaTVHealthCheck : IHealthCheck
     {
         try
         {
-            var channels = await _magentaService.GetChannelsAsync();
+            var channels = await _channelService.GetChannelsAsync();
 
             var data = new Dictionary<string, object>
             {

--- a/MagentaTV/Services/Background/Services/CacheWarmingService.cs
+++ b/MagentaTV/Services/Background/Services/CacheWarmingService.cs
@@ -1,6 +1,7 @@
 ﻿using MagentaTV.Services.Background.Core;
 using MagentaTV.Services.Background.Events;
 using MagentaTV.Services.TokenStorage;
+using MagentaTV.Services.Channels;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace MagentaTV.Services.Background.Services
@@ -27,7 +28,7 @@ namespace MagentaTV.Services.Background.Services
                 await ExecuteWithEventsAsync("CacheWarming", async () =>
                 {
                     using var scope = CreateScope();
-                    var magentaService = scope.ServiceProvider.GetRequiredService<IMagenta>();
+                    var channelService = scope.ServiceProvider.GetRequiredService<IChannelService>();
                     var tokenStorage = scope.ServiceProvider.GetRequiredService<ITokenStorage>();
                     var cache = scope.ServiceProvider.GetRequiredService<IMemoryCache>();
 
@@ -52,7 +53,7 @@ namespace MagentaTV.Services.Background.Services
 
                     try
                     {
-                        var channels = await magentaService.GetChannelsAsync();
+                        var channels = await channelService.GetChannelsAsync();
                         Logger.LogInformation("Cache warmed with {ChannelCount} channels", channels.Count);
 
                         // Update metrics
@@ -116,9 +117,9 @@ namespace MagentaTV.Services.Background.Services
                 Logger.LogInformation("Manual cache warming triggered");
 
                 using var scope = CreateScope();
-                var magentaService = scope.ServiceProvider.GetRequiredService<IMagenta>();
+                var channelService = scope.ServiceProvider.GetRequiredService<IChannelService>();
 
-                var channels = await magentaService.GetChannelsAsync();
+                var channels = await channelService.GetChannelsAsync();
                 Logger.LogInformation("Manual cache warming completed with {ChannelCount} channels", channels.Count);
 
                 SetMetric("manual_warms", GetMetric<long>("manual_warms") + 1);

--- a/MagentaTV/Services/Channels/ChannelService.cs
+++ b/MagentaTV/Services/Channels/ChannelService.cs
@@ -1,0 +1,25 @@
+using MagentaTV.Models;
+
+namespace MagentaTV.Services.Channels;
+
+public class ChannelService : IChannelService
+{
+    private readonly IMagenta _magenta;
+    private readonly ILogger<ChannelService> _logger;
+
+    public ChannelService(IMagenta magenta, ILogger<ChannelService> logger)
+    {
+        _magenta = magenta;
+        _logger = logger;
+    }
+
+    public Task<List<ChannelDto>> GetChannelsAsync()
+    {
+        return _magenta.GetChannelsAsync();
+    }
+
+    public Task<string> GenerateM3UPlaylistAsync()
+    {
+        return _magenta.GenerateM3UPlaylistAsync();
+    }
+}

--- a/MagentaTV/Services/Channels/IChannelService.cs
+++ b/MagentaTV/Services/Channels/IChannelService.cs
@@ -1,0 +1,9 @@
+using MagentaTV.Models;
+
+namespace MagentaTV.Services.Channels;
+
+public interface IChannelService
+{
+    Task<List<ChannelDto>> GetChannelsAsync();
+    Task<string> GenerateM3UPlaylistAsync();
+}

--- a/MagentaTV/Services/Epg/EpgService.cs
+++ b/MagentaTV/Services/Epg/EpgService.cs
@@ -1,0 +1,25 @@
+using MagentaTV.Models;
+
+namespace MagentaTV.Services.Epg;
+
+public class EpgService : IEpgService
+{
+    private readonly IMagenta _magenta;
+    private readonly ILogger<EpgService> _logger;
+
+    public EpgService(IMagenta magenta, ILogger<EpgService> logger)
+    {
+        _magenta = magenta;
+        _logger = logger;
+    }
+
+    public Task<List<EpgItemDto>> GetEpgAsync(int channelId, DateTime? from = null, DateTime? to = null)
+    {
+        return _magenta.GetEpgAsync(channelId, from, to);
+    }
+
+    public string GenerateXmlTv(List<EpgItemDto> epg, int channelId)
+    {
+        return _magenta.GenerateXmlTv(epg, channelId);
+    }
+}

--- a/MagentaTV/Services/Epg/IEpgService.cs
+++ b/MagentaTV/Services/Epg/IEpgService.cs
@@ -1,0 +1,9 @@
+using MagentaTV.Models;
+
+namespace MagentaTV.Services.Epg;
+
+public interface IEpgService
+{
+    Task<List<EpgItemDto>> GetEpgAsync(int channelId, DateTime? from = null, DateTime? to = null);
+    string GenerateXmlTv(List<EpgItemDto> epg, int channelId);
+}

--- a/MagentaTV/Services/Stream/IStreamService.cs
+++ b/MagentaTV/Services/Stream/IStreamService.cs
@@ -1,0 +1,7 @@
+namespace MagentaTV.Services.Stream;
+
+public interface IStreamService
+{
+    Task<string?> GetStreamUrlAsync(int channelId);
+    Task<string?> GetCatchupStreamUrlAsync(long scheduleId);
+}

--- a/MagentaTV/Services/Stream/StreamService.cs
+++ b/MagentaTV/Services/Stream/StreamService.cs
@@ -1,0 +1,23 @@
+namespace MagentaTV.Services.Stream;
+
+public class StreamService : IStreamService
+{
+    private readonly IMagenta _magenta;
+    private readonly ILogger<StreamService> _logger;
+
+    public StreamService(IMagenta magenta, ILogger<StreamService> logger)
+    {
+        _magenta = magenta;
+        _logger = logger;
+    }
+
+    public Task<string?> GetStreamUrlAsync(int channelId)
+    {
+        return _magenta.GetStreamUrlAsync(channelId);
+    }
+
+    public Task<string?> GetCatchupStreamUrlAsync(long scheduleId)
+    {
+        return _magenta.GetCatchupStreamUrlAsync(scheduleId);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce ChannelService, EpgService and StreamService wrappers
- register new services in DI
- refactor queries, event handlers and background tasks to use new services
- update health check to rely on ChannelService

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cfa2484083269e11a8ff21047ef7