### PR TITLE
Improve English documentation

### DIFF
--- a/MagentaTV/Controllers/AuthController.cs
+++ b/MagentaTV/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿using MagentaTV.Application.Commands;
+using MagentaTV.Application.Commands;
 using MagentaTV.Models;
 using MagentaTV.Models.Session;
 using MediatR;
@@ -9,6 +9,10 @@ namespace MagentaTV.Controllers
 {
     [ApiController]
     [Route("auth")]
+    /// <summary>
+    /// Handles authentication related endpoints such as logging in and out.
+    /// All responses are returned using the <see cref="ApiResponse{T}"/> wrapper.
+    /// </summary>
     public class AuthController : ControllerBase
     {
         private readonly IMediator _mediator;
@@ -21,7 +25,8 @@ namespace MagentaTV.Controllers
         }
 
         /// <summary>
-        /// Unified login endpoint - ověří credentials + vytvoří session
+        /// Central login endpoint that validates user credentials and creates
+        /// a new application session when successful.
         /// </summary>
         [HttpPost("login")]
         [ProducesResponseType(typeof(ApiResponse<SessionCreatedDto>), 200)]
@@ -63,7 +68,8 @@ namespace MagentaTV.Controllers
         }
 
         /// <summary>
-        /// Logout endpoint
+        /// Terminates the current session and removes the session cookie from
+        /// the client.
         /// </summary>
         [HttpPost("logout")]
         [ProducesResponseType(typeof(ApiResponse<string>), 200)]

--- a/MagentaTV/Controllers/MagentaController.cs
+++ b/MagentaTV/Controllers/MagentaController.cs
@@ -1,4 +1,4 @@
-﻿using MagentaTV.Application.Commands;
+using MagentaTV.Application.Commands;
 using MagentaTV.Application.Queries;
 using MagentaTV.Extensions;
 using MagentaTV.Models;
@@ -9,6 +9,10 @@ namespace MagentaTV.Controllers;
 
 [ApiController]
 [Route("magenta")]
+/// <summary>
+/// API endpoints that act as a thin wrapper over the underlying MagentaTV
+/// service. Requires an active session for most operations.
+/// </summary>
 public class MagentaController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -21,7 +25,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Získání stavu autentizace - kombinuje session + token data
+    /// Returns authentication status by combining current session details and
+    /// stored token information.
     /// </summary>
     [HttpGet("auth/status")]
     [ProducesResponseType(typeof(ApiResponse<AuthStatusDto>), 200)]
@@ -33,7 +38,7 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Získání seznamu kanálů - vyžaduje aktivní session
+    /// Retrieves the list of available channels. Requires an active session.
     /// </summary>
     [HttpGet("channels")]
     [ProducesResponseType(typeof(ApiResponse<List<ChannelDto>>), 200)]
@@ -55,7 +60,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Získání EPG pro kanál - vyžaduje aktivní session
+    /// Returns the Electronic Program Guide for the specified channel. Requires
+    /// an active session.
     /// </summary>
     [HttpGet("epg/{channelId}")]
     [ProducesResponseType(typeof(ApiResponse<List<EpgItemDto>>), 200)]
@@ -88,7 +94,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Získání stream URL pro kanál - vyžaduje aktivní session
+    /// Retrieves the streaming URL for the given channel. An active session is
+    /// required to access the stream.
     /// </summary>
     [HttpGet("stream/{channelId}")]
     [ProducesResponseType(typeof(ApiResponse<StreamUrlDto>), 200)]
@@ -122,7 +129,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Získání catchup stream URL - vyžaduje aktivní session
+    /// Retrieves the catch-up streaming URL for the specified schedule entry.
+    /// Requires an active session.
     /// </summary>
     [HttpGet("catchup/{scheduleId}")]
     [ProducesResponseType(typeof(ApiResponse<StreamUrlDto>), 200)]
@@ -156,7 +164,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Generování M3U playlistu - vyžaduje aktivní session
+    /// Generates an M3U playlist for the authenticated user. Requires an active
+    /// session to obtain channel data and streaming URLs.
     /// </summary>
     [HttpGet("playlist")]
     [ProducesResponseType(typeof(FileResult), 200)]
@@ -185,7 +194,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Export EPG ve formátu XMLTV - vyžaduje aktivní session
+    /// Exports the EPG for a channel as an XMLTV document. Requires an active
+    /// session.
     /// </summary>
     [HttpGet("epgxml/{channelId}")]
     [ProducesResponseType(typeof(FileResult), 200)]
@@ -221,7 +231,8 @@ public class MagentaController : ControllerBase
     }
 
     /// <summary>
-    /// Ověření připojení k MagentaTV API - kombinuje session + token info
+    /// Performs a connectivity check against the MagentaTV API and returns
+    /// information about the current session and token validity.
     /// </summary>
     [HttpGet("ping")]
     [ProducesResponseType(typeof(ApiResponse<PingResultDto>), 200)]

--- a/MagentaTV/Controllers/SessionController.cs
+++ b/MagentaTV/Controllers/SessionController.cs
@@ -1,4 +1,4 @@
-﻿using MagentaTV.Application.Commands;
+using MagentaTV.Application.Commands;
 using MagentaTV.Application.Queries;
 using MagentaTV.Models;
 using MagentaTV.Models.Session;
@@ -11,6 +11,11 @@ namespace MagentaTV.Controllers;
 
 [ApiController]
 [Route("sessions")]
+/// <summary>
+/// Provides endpoints for inspecting and manipulating user sessions. These
+/// endpoints require a valid session cookie and are primarily used for
+/// session management in the UI.
+/// </summary>
 public class SessionController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -24,7 +29,7 @@ public class SessionController : ControllerBase
 
 
     /// <summary>
-    /// Získá informace o current session
+    /// Returns details for the currently active session.
     /// </summary>
     [HttpGet("current")]
     [ProducesResponseType(typeof(ApiResponse<SessionInfoDto>), 200)]
@@ -50,7 +55,7 @@ public class SessionController : ControllerBase
     }
 
     /// <summary>
-    /// Získá všechny sessions současného uživatele
+    /// Retrieves a list of all sessions associated with the current user.
     /// </summary>
     [HttpGet("user")]
     [ProducesResponseType(typeof(ApiResponse<List<SessionDto>>), 200)]
@@ -76,7 +81,7 @@ public class SessionController : ControllerBase
 
 
     /// <summary>
-    /// Ukončí konkrétní session
+    /// Revokes a specific session identified by <paramref name="sessionId"/>.
     /// </summary>
     [HttpPost("revoke/{sessionId}")]
     [ProducesResponseType(typeof(ApiResponse<string>), 200)]
@@ -111,7 +116,9 @@ public class SessionController : ControllerBase
         return Ok(result);
     }
 
-    /// Ukončí všechny sessions uživatele kromě současné
+    /// <summary>
+    /// Logs out every session for the current user except the one making the
+    /// request.
     /// </summary>
     [HttpPost("logout-all")]
     [ProducesResponseType(typeof(ApiResponse<string>), 200)]
@@ -136,7 +143,7 @@ public class SessionController : ControllerBase
     }
 
     /// <summary>
-    /// Získá statistiky sessions (admin endpoint)
+    /// Retrieves aggregated session statistics. Intended for administrative use.
     /// </summary>
     [HttpGet("statistics")]
     [ProducesResponseType(typeof(ApiResponse<SessionStatistics>), 200)]

--- a/MagentaTV/Hubs/NotificationHub.cs
+++ b/MagentaTV/Hubs/NotificationHub.cs
@@ -2,8 +2,18 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace MagentaTV.Hubs
 {
+    /// <summary>
+    /// SignalR hub used to broadcast simple notifications to all connected
+    /// clients. At the moment it only exposes a single method that relays a
+    /// message to every subscriber.
+    /// </summary>
     public class NotificationHub : Hub
     {
+        /// <summary>
+        /// Sends a chat style message to all connected clients.
+        /// </summary>
+        /// <param name="user">Name of the sender.</param>
+        /// <param name="message">Message text.</param>
         public async Task SendMessage(string user, string message) =>
             await Clients.All.SendAsync("ReceiveMessage", user, message);
     }

--- a/MagentaTV/Models/ApiResponse.cs
+++ b/MagentaTV/Models/ApiResponse.cs
@@ -1,5 +1,11 @@
-﻿namespace MagentaTV.Models;
+namespace MagentaTV.Models;
 
+/// <summary>
+/// Generic wrapper used for all API responses.  The <typeparamref name="T"/>
+/// parameter represents the actual payload returned to the client.  The object
+/// also contains common metadata such as success flag, message, validation
+/// errors and a timestamp.
+/// </summary>
 public class ApiResponse<T>
 {
     public bool Success { get; set; }
@@ -8,6 +14,11 @@ public class ApiResponse<T>
     public List<string> Errors { get; set; } = new();
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Creates a successful response with an optional descriptive message.
+    /// </summary>
+    /// <param name="data">Payload to send to the caller.</param>
+    /// <param name="message">Optional message describing the outcome.</param>
     public static ApiResponse<T> SuccessResult(T data, string? message = null)
     {
         return new ApiResponse<T>
@@ -18,6 +29,12 @@ public class ApiResponse<T>
         };
     }
 
+    /// <summary>
+    /// Creates an error response.  A list of validation errors can be provided
+    /// for additional context.
+    /// </summary>
+    /// <param name="message">Human readable error message.</param>
+    /// <param name="errors">Optional collection of validation errors.</param>
     public static ApiResponse<T> ErrorResult(string message, List<string>? errors = null)
     {
         return new ApiResponse<T>

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -1,3 +1,5 @@
+// Entry point for the MagentaTV REST API wrapper. This file configures
+// dependency injection, middlewares and starts the ASP.NET Core application.
 using MagentaTV.Configuration;
 using MagentaTV.Services;
 using MagentaTV.Services.Channels;

--- a/MagentaTV/Services/Magenta.cs
+++ b/MagentaTV/Services/Magenta.cs
@@ -1,4 +1,4 @@
-﻿using MagentaTV.Configuration;
+using MagentaTV.Configuration;
 using MagentaTV.Models;
 using MagentaTV.Services;
 using MagentaTV.Services.TokenStorage;
@@ -12,6 +12,11 @@ using System.Xml.Linq;
 
 namespace MagentaTV.Services
 {
+    /// <summary>
+    /// High level client responsible for communicating with the MagentaTV API
+    /// and caching results. It also manages authentication tokens via
+    /// <see cref="ITokenStorage"/>.
+    /// </summary>
     public class Magenta : IMagenta
     {
         private readonly HttpClient _httpClient;
@@ -81,6 +86,14 @@ namespace MagentaTV.Services
             }
         }
 
+        /// <summary>
+        /// Performs a full login flow using the provided user credentials.
+        /// The method initializes a device session, authenticates the user and
+        /// persists the received tokens if configured to do so.
+        /// </summary>
+        /// <param name="username">MagentaTV account name.</param>
+        /// <param name="password">Password for the account.</param>
+        /// <returns><c>true</c> when login succeeded.</returns>
         public async Task<bool> LoginAsync(string username, string password)
         {
             var stopwatch = Stopwatch.StartNew();


### PR DESCRIPTION
## Summary
- clarify API response generics
- document NotificationHub
- document authentication controller
- document session management endpoints
- document MagentaTV controller endpoints
- explain cache warming background service
- summarize Magenta service purpose
- note entry point responsibilities

## Testing
- `dotnet test MagentaTV.sln -c Release` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4ccee50832686e8b83e7fe92da2