### PR TITLE
Integrate SignalR event broadcasting

### DIFF
--- a/MagentaTV/Application/EventHandlers/TokensRefreshedEventHandler.cs
+++ b/MagentaTV/Application/EventHandlers/TokensRefreshedEventHandler.cs
@@ -1,4 +1,6 @@
 ﻿using MagentaTV.Application.Events;
+using MagentaTV.Hubs;
+using Microsoft.AspNetCore.SignalR;
 using MagentaTV.Services.Session;
 using MediatR;
 
@@ -8,13 +10,16 @@ namespace MagentaTV.Application.EventHandlers
     {
         private readonly ISessionManager _sessionManager;
         private readonly ILogger<TokensRefreshedEventHandler> _logger;
+        private readonly IHubContext<NotificationHub> _hubContext;
 
         public TokensRefreshedEventHandler(
             ISessionManager sessionManager,
-            ILogger<TokensRefreshedEventHandler> logger)
+            ILogger<TokensRefreshedEventHandler> logger,
+            IHubContext<NotificationHub> hubContext)
         {
             _sessionManager = sessionManager;
             _logger = logger;
+            _hubContext = hubContext;
         }
 
         public async Task Handle(TokensRefreshedEvent notification, CancellationToken cancellationToken)
@@ -29,6 +34,8 @@ namespace MagentaTV.Application.EventHandlers
                 // This would need TokenData - simplified for example
                 _logger.LogDebug("Updated session {SessionId} with new token expiry", session.SessionId);
             }
+
+            await _hubContext.Clients.All.SendAsync("TokensRefreshed", notification, cancellationToken);
         }
     }
 }

--- a/MagentaTV/Application/EventHandlers/UserLoggedInEventHandler.cs
+++ b/MagentaTV/Application/EventHandlers/UserLoggedInEventHandler.cs
@@ -1,4 +1,6 @@
 ﻿using MagentaTV.Application.Events;
+using MagentaTV.Hubs;
+using Microsoft.AspNetCore.SignalR;
 using MagentaTV.Models;
 using MagentaTV.Services.Background;
 using MagentaTV.Services.Channels;
@@ -14,13 +16,16 @@ namespace MagentaTV.Application.EventHandlers
     {
         private readonly IBackgroundServiceManager _backgroundManager;
         private readonly ILogger<UserLoggedInEventHandler> _logger;
+        private readonly IHubContext<NotificationHub> _hubContext;
 
         public UserLoggedInEventHandler(
             IBackgroundServiceManager backgroundManager,
-            ILogger<UserLoggedInEventHandler> logger)
+            ILogger<UserLoggedInEventHandler> logger,
+            IHubContext<NotificationHub> hubContext)
         {
             _backgroundManager = backgroundManager;
             _logger = logger;
+            _hubContext = hubContext;
         }
 
         public async Task Handle(UserLoggedInEvent notification, CancellationToken cancellationToken)
@@ -48,6 +53,8 @@ namespace MagentaTV.Application.EventHandlers
                 _logger.LogError(ex, "Failed to queue post-login tasks for user {Username}", notification.Username);
                 // Nebudeme házet exception - login už proběhl úspěšně
             }
+
+            await _hubContext.Clients.All.SendAsync("UserLoggedIn", notification, cancellationToken);
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Tento repozitář obsahuje ASP.NET Core aplikaci poskytující REST rozhraní pr
 - **Autentizace a správa session** – koncové body v `AuthController` a `SessionController`
 - **Získání kanálů, EPG a streamů** – koncové body v `MagentaController`
 - **Generování M3U playlistu a XMLTV**
-- **SignalR hub** pro zasílání notifikací
+- **SignalR hub** pro zasílání notifikací (`/hubs/notifications`).
+  Klienti mohou přijímat události o přihlášení, odhlášení uživatele
+  i o dokončení FFmpeg úloh prostřednictvím knihovny SignalR.
 - **Health checks** pro kontrolu dostupnosti služeb a background úloh
 
 ## Spuštění v režimu vývoje


### PR DESCRIPTION
## Summary
- broadcast important domain events to clients via SignalR
- describe SignalR notifications in README

## Testing
- `dotnet build MagentaTV.sln -v:q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430254d444832687127ac9e781b654