### PR TITLE
Fix ffmpeg service call chain

### DIFF
--- a/MagentaTV.Client/MagentaTvClient.cs
+++ b/MagentaTV.Client/MagentaTvClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text;
 using MagentaTV.Client.Models;
+using MagentaTV.Client.Models.Session;
 
 namespace MagentaTV.Client;
 

--- a/MagentaTV/Services/Ffmpeg/FFmpegService.cs
+++ b/MagentaTV/Services/Ffmpeg/FFmpegService.cs
@@ -43,7 +43,8 @@ public class FFmpegService : IFFmpegService
                     await FFMpegArguments
                         .FromUrlInput(new Uri(inputUrl))
                         .OutputToFile(outputFile, overwrite: true)
-                        .ProcessAsynchronously(false, ct);
+                        .CancellableThrough(ct)
+                        .ProcessAsynchronously(false);
                     status.IsSuccess = true;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Summary
- make FFmpeg conversion chain cancellable
- include session DTO namespace for client build

## Testing
- `~/dotnet9/dotnet restore MagentaTV.sln`
- `~/dotnet9/dotnet build MagentaTV.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6843241c651c832699e140dfb10bbef1