### PR TITLE
Add advanced error handling middleware

### DIFF
--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -219,7 +219,7 @@ if (app.Environment.IsDevelopment())
 app.UseMiddleware<SecurityHeadersMiddleware>();
 
 // Exception handling middleware
-app.UseMiddleware<ExceptionHandlingMiddleware>();
+app.UseMiddleware<GlobalExceptionMiddleware>();
 
 // Request/Response logging (only in development)
 if (app.Environment.IsDevelopment())

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tento repozitář obsahuje ASP.NET Core aplikaci poskytující REST rozhraní pr
 - **Health checks** pro kontrolu dostupnosti služeb a background úloh
 - **Barevná konzole** využívající [Spectre.Console](https://spectreconsole.net)
   pro přehledné panely a informační hlášky
+- **Pokročilé zpracování chyb** pomocí vlastního middleware, který vrací `ApiResponse` s identifikátorem chyby
 
 ## Spuštění v režimu vývoje
 ```bash


### PR DESCRIPTION
## Summary
- replace simple exception middleware with `GlobalExceptionMiddleware`
- extend `GlobalExceptionMiddleware` with correlation IDs and more mappings
- document advanced error handling in README

## Testing
- `dotnet build MagentaTV.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843285bb03c8326a85b6f4895ab2eff