### PR TITLE
Load session data into HttpContext

### DIFF
--- a/MagentaTV/Application/Behaviors/SessionValidationBehavior.cs
+++ b/MagentaTV/Application/Behaviors/SessionValidationBehavior.cs
@@ -47,6 +47,20 @@ namespace MagentaTV.Application.Behaviors
                 throw new UnauthorizedAccessException("Invalid session");
             }
 
+            // Načti session data pro pozdější použití
+            _logger.LogDebug("Loading session data for {SessionId}", sessionId);
+            var sessionData = await _sessionManager.GetSessionAsync(sessionId);
+            if (sessionData == null)
+            {
+                _logger.LogWarning("Session {SessionId} validated but no data found", sessionId);
+            }
+            else
+            {
+                httpContext.Items["CurrentSession"] = sessionData;
+                httpContext.Items["CurrentUsername"] = sessionData.Username;
+                _logger.LogDebug("Session data set in HttpContext for {Username}", sessionData.Username);
+            }
+
             // Aktualizuj aktivitu
             await _sessionManager.UpdateSessionActivityAsync(sessionId);
 


### PR DESCRIPTION
## Summary
- load session data after session validation
- store current session and username in `HttpContext.Items`
- log debug information for loading and setting session data
- warn when valid session is missing data

## Testing
- `dotnet test MagentaTV.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432b0365d48326925dd203316d8542