### PR TITLE
Implement network configuration

### DIFF
--- a/MagentaTV/Configuration/NetworkOptions.cs
+++ b/MagentaTV/Configuration/NetworkOptions.cs
@@ -6,6 +6,11 @@ public class NetworkOptions
 {
     public const string SectionName = "Network";
 
+    /// <summary>
+    /// Name of the network interface to configure (e.g. "eth0" or "Ethernet").
+    /// </summary>
+    public string InterfaceName { get; set; } = "eth0";
+
     [RegularExpression(@"^\d{1,3}(\.\d{1,3}){3}$")]
     public string IpAddress { get; set; } = "127.0.0.1";
 
@@ -31,4 +36,10 @@ public class NetworkOptions
     public bool EnableSsl { get; set; } = true;
 
     public bool ValidateServerCertificate { get; set; } = true;
+
+    [Range(0, 86400)]
+    public int PooledConnectionLifetimeSeconds { get; set; } = 0;
+
+    [Range(0, 86400)]
+    public int PooledConnectionIdleTimeoutSeconds { get; set; } = 0;
 }

--- a/MagentaTV/Program.cs
+++ b/MagentaTV/Program.cs
@@ -204,6 +204,10 @@ AnsiConsole.Write(new Panel(infoTable)
     Padding = new Padding(1, 1, 1, 1)
 });
 
+// Apply network configuration before starting services
+var networkService = app.Services.GetRequiredService<INetworkService>();
+await networkService.ConfigureNetworkAsync();
+
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())
 {

--- a/MagentaTV/Services/Network/INetworkService.cs
+++ b/MagentaTV/Services/Network/INetworkService.cs
@@ -1,4 +1,6 @@
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using MagentaTV.Configuration;
 
 namespace MagentaTV.Services.Network;
@@ -6,5 +8,6 @@ namespace MagentaTV.Services.Network;
 public interface INetworkService
 {
     HttpMessageHandler CreateHttpMessageHandler();
+    Task ConfigureNetworkAsync(CancellationToken cancellationToken = default);
     NetworkOptions Options { get; }
 }

--- a/MagentaTV/Services/Network/NetworkService.cs
+++ b/MagentaTV/Services/Network/NetworkService.cs
@@ -1,5 +1,10 @@
 using System.Net;
 using System.Net.Http;
+using System.Diagnostics;
+using System.Text;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MagentaTV.Configuration;
 
@@ -18,6 +23,79 @@ public class NetworkService : INetworkService
 
     public NetworkOptions Options => _options;
 
+    public async Task ConfigureNetworkAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(_options.InterfaceName))
+            {
+                _logger.LogWarning("InterfaceName not specified, skipping network configuration");
+                return;
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                await RunProcessAsync("netsh",
+                    $"interface ip set address name=\"{_options.InterfaceName}\" static {_options.IpAddress} {_options.SubnetMask} {_options.Gateway}", cancellationToken);
+
+                if (_options.DnsServers.Length > 0)
+                {
+                    await RunProcessAsync("netsh", $"interface ip set dns name=\"{_options.InterfaceName}\" static {_options.DnsServers[0]} primary", cancellationToken);
+
+                    for (int i = 1; i < _options.DnsServers.Length; i++)
+                    {
+                        await RunProcessAsync("netsh", $"interface ip add dns name=\"{_options.InterfaceName}\" {_options.DnsServers[i]}", cancellationToken);
+                    }
+                }
+            }
+            else if (OperatingSystem.IsLinux())
+            {
+                await RunProcessAsync("ip", $"addr flush dev {_options.InterfaceName}", cancellationToken);
+                await RunProcessAsync("ip", $"addr add {_options.IpAddress}/{SubnetMaskToCidr(_options.SubnetMask)} dev {_options.InterfaceName}", cancellationToken);
+                await RunProcessAsync("ip", $"route add default via {_options.Gateway}", cancellationToken);
+
+                var resolv = new StringBuilder();
+                foreach (var dns in _options.DnsServers)
+                {
+                    resolv.AppendLine($"nameserver {dns}");
+                }
+                await File.WriteAllTextAsync("/etc/resolv.conf", resolv.ToString(), cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to apply network configuration");
+        }
+    }
+
+    private static async Task RunProcessAsync(string fileName, string arguments, CancellationToken cancellationToken)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            }
+        };
+
+        process.Start();
+        await process.WaitForExitAsync(cancellationToken);
+    }
+
+    private static int SubnetMaskToCidr(string mask)
+    {
+        var parts = mask.Split('.');
+        int cidr = 0;
+        foreach (var part in parts)
+        {
+            cidr += Convert.ToString(int.Parse(part), 2).Count(c => c == '1');
+        }
+        return cidr;
+    }
+
     public HttpMessageHandler CreateHttpMessageHandler()
     {
         var handler = new SocketsHttpHandler
@@ -25,6 +103,16 @@ public class NetworkService : INetworkService
             MaxConnectionsPerServer = _options.MaxConnectionsPerServer,
             ConnectTimeout = TimeSpan.FromSeconds(_options.ConnectionTimeoutSeconds)
         };
+
+        if (_options.PooledConnectionLifetimeSeconds > 0)
+        {
+            handler.PooledConnectionLifetime = TimeSpan.FromSeconds(_options.PooledConnectionLifetimeSeconds);
+        }
+
+        if (_options.PooledConnectionIdleTimeoutSeconds > 0)
+        {
+            handler.PooledConnectionIdleTimeout = TimeSpan.FromSeconds(_options.PooledConnectionIdleTimeoutSeconds);
+        }
 
         if (!string.IsNullOrEmpty(_options.ProxyAddress))
         {

--- a/MagentaTV/appsettings.Development.json
+++ b/MagentaTV/appsettings.Development.json
@@ -86,6 +86,7 @@
   },
 
   "Network": {
+    "InterfaceName": "eth0",
     "IpAddress": "192.168.1.50",
     "SubnetMask": "255.255.255.0",
     "Gateway": "192.168.1.1",
@@ -95,7 +96,9 @@
     "MaxConnectionsPerServer": 10,
     "ConnectionTimeoutSeconds": 60,
     "EnableSsl": true,
-    "ValidateServerCertificate": true
+    "ValidateServerCertificate": true,
+    "PooledConnectionLifetimeSeconds": 0,
+    "PooledConnectionIdleTimeoutSeconds": 0
   },
 
   "HealthChecks": {

--- a/MagentaTV/appsettings.json
+++ b/MagentaTV/appsettings.json
@@ -90,6 +90,7 @@
   },
 
   "Network": {
+    "InterfaceName": "eth0",
     "IpAddress": "192.168.168.47",
     "SubnetMask": "255.255.255.0",
     "Gateway": "192.168.168.1",
@@ -99,7 +100,9 @@
     "MaxConnectionsPerServer": 20,
     "ConnectionTimeoutSeconds": 30,
     "EnableSsl": true,
-    "ValidateServerCertificate": true
+    "ValidateServerCertificate": true,
+    "PooledConnectionLifetimeSeconds": 0,
+    "PooledConnectionIdleTimeoutSeconds": 0
   },
 
   "FFmpeg": {

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -27,6 +27,7 @@
   },
 
   "Network": {
+    "InterfaceName": "eth0",
     "IpAddress": "192.168.1.200",
     "SubnetMask": "255.255.255.0",
     "Gateway": "192.168.1.1",
@@ -36,7 +37,9 @@
     "MaxConnectionsPerServer": 50,
     "ConnectionTimeoutSeconds": 20,
     "EnableSsl": true,
-    "ValidateServerCertificate": true
+    "ValidateServerCertificate": true,
+    "PooledConnectionLifetimeSeconds": 0,
+    "PooledConnectionIdleTimeoutSeconds": 0
   },
 
   "HealthChecks": {


### PR DESCRIPTION
## Summary
- extend `NetworkOptions` with interface name and connection pooling settings
- add `ConfigureNetworkAsync` to `INetworkService` and implement it in `NetworkService`
- apply network settings during application startup
- expose new configuration fields in `appsettings.json` files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684330a3323c832681f6da24994e5597