### PR TITLE
Fix async implementations

### DIFF
--- a/MagentaTV.Client/MagentaTvClient.cs
+++ b/MagentaTV.Client/MagentaTvClient.cs
@@ -116,7 +116,7 @@ public class MagentaTvClient
         var completed = await Task.WhenAny(receiveTask, Task.Delay(timeoutMs));
         if (completed == receiveTask)
         {
-            var result = receiveTask.Result;
+            var result = await receiveTask;
             var message = Encoding.UTF8.GetString(result.Buffer);
             const string prefix = "MAGENTATV_DISCOVERY_RESPONSE|";
             if (message.StartsWith(prefix))

--- a/MagentaTV/Services/Background/Services/CacheWarmingService.cs
+++ b/MagentaTV/Services/Background/Services/CacheWarmingService.cs
@@ -176,16 +176,16 @@ namespace MagentaTV.Services.Background.Services
         /// <summary>
         /// Adds cache-warming specific metrics to the service health report.
         /// </summary>
-        public override Task<ServiceHealth> GetHealthAsync()
+        public override async Task<ServiceHealth> GetHealthAsync()
         {
-            var baseHealth = base.GetHealthAsync().Result;
+            var baseHealth = await base.GetHealthAsync();
 
             // Přidáme cache warming specific metriky
             baseHealth.Metrics["has_warmed_after_login"] = _hasWarmedAfterLogin;
             baseHealth.Metrics["last_successful_warm"] = _lastSuccessfulWarm;
             baseHealth.Metrics["time_since_last_warm"] = DateTime.UtcNow - _lastSuccessfulWarm;
 
-            return Task.FromResult(baseHealth);
+            return baseHealth;
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid blocking call in discovery helper
- make cache warming GetHealthAsync fully async

## Testing
- `dotnet build` *(fails: NETSDK1045 – requires newer .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6843463ed7a4832687159ce5e735a163