### PR TITLE
Add MSTest unit tests

### DIFF
--- a/MagentaTV.Tests/BackgroundServiceExtensionsTests.cs
+++ b/MagentaTV.Tests/BackgroundServiceExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MagentaTV.Extensions;
+using MagentaTV.Services.Background.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class BackgroundServiceExtensionsTests
+{
+    [TestMethod]
+    public void CreateWorkItem_SetsProperties()
+    {
+        var item = BackgroundServiceExtensions.CreateWorkItem(
+            "name",
+            "type",
+            (_,_) => Task.CompletedTask,
+            5);
+
+        Assert.AreEqual("name", item.Name);
+        Assert.AreEqual("type", item.Type);
+        Assert.AreEqual(5, item.Priority);
+        Assert.IsNotNull(item.WorkItem);
+    }
+
+    [TestMethod]
+    public void CreateScheduledWorkItem_SetsDate()
+    {
+        var future = DateTime.UtcNow.AddDays(1);
+        var item = BackgroundServiceExtensions.CreateScheduledWorkItem(
+            "name",
+            "type",
+            (_,_) => Task.CompletedTask,
+            future,
+            1);
+
+        Assert.AreEqual(future, item.ScheduledFor);
+        Assert.AreEqual(1, item.Priority);
+    }
+}

--- a/MagentaTV.Tests/EpgItemDtoTests.cs
+++ b/MagentaTV.Tests/EpgItemDtoTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MagentaTV.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class EpgItemDtoTests
+{
+    [TestMethod]
+    public void Validate_ReturnsError_WhenDurationTooLong()
+    {
+        var dto = new EpgItemDto
+        {
+            Title = "Test",
+            StartTime = DateTime.UtcNow,
+            EndTime = DateTime.UtcNow.AddHours(9),
+            ScheduleId = 1
+        };
+
+        var results = dto.Validate(new ValidationContext(dto)).ToList();
+        Assert.IsTrue(results.Any(r => r.ErrorMessage!.Contains("duration")));
+    }
+}

--- a/MagentaTV.Tests/MSTestSettings.cs
+++ b/MagentaTV.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/MagentaTV.Tests/MagentaTV.Tests.csproj
+++ b/MagentaTV.Tests/MagentaTV.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest" Version="3.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MagentaTV\MagentaTV.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/MagentaTV.Tests/MagentaTVOptionsTests.cs
+++ b/MagentaTV.Tests/MagentaTVOptionsTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MagentaTV.Configuration;
+using MagentaTV.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class MagentaTVOptionsTests
+{
+    [TestMethod]
+    public void ValidateTimeRange_ReturnsError_WhenEndBeforeStart()
+    {
+        var dto = new EpgItemDto
+        {
+            StartTime = DateTime.UtcNow,
+            EndTime = DateTime.UtcNow.AddHours(-1)
+        };
+
+        var result = MagentaTVOptions.ValidateTimeRange(dto, new ValidationContext(dto));
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public void ValidateTimeRange_Succeeds_WhenEndAfterStart()
+    {
+        var dto = new EpgItemDto
+        {
+            StartTime = DateTime.UtcNow,
+            EndTime = DateTime.UtcNow.AddHours(1)
+        };
+
+        var result = MagentaTVOptions.ValidateTimeRange(dto, new ValidationContext(dto));
+        Assert.IsNull(result);
+    }
+}

--- a/MagentaTV.Tests/SecurityExtensionsTests.cs
+++ b/MagentaTV.Tests/SecurityExtensionsTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MagentaTV.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class SecurityExtensionsTests
+{
+    [TestMethod]
+    public void AddSecurityValidation_Throws_WhenMissingEnvVars_InProduction()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+        var inMemory = new Dictionary<string, string?>
+        {
+            ["Session:EncryptionKey"] = "development-key"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(inMemory).Build();
+        var services = new ServiceCollection();
+
+        Assert.ThrowsException<InvalidOperationException>(() => services.AddSecurityValidation(config));
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+    }
+}

--- a/MagentaTV.Tests/SessionCookieHelperTests.cs
+++ b/MagentaTV.Tests/SessionCookieHelperTests.cs
@@ -1,0 +1,51 @@
+using System;
+using MagentaTV.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class SessionCookieHelperTests
+{
+    [TestMethod]
+    public void GetSessionId_ReturnsId_FromCookie()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append("Cookie", "SessionId=abc");
+
+        var result = SessionCookieHelper.GetSessionId(context.Request);
+        Assert.AreEqual("abc", result);
+    }
+
+    [TestMethod]
+    public void GetSessionId_ReturnsId_FromAuthorizationHeader()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Authorization = "Session xyz";
+
+        var result = SessionCookieHelper.GetSessionId(context.Request);
+        Assert.AreEqual("xyz", result);
+    }
+
+    [TestMethod]
+    public void SetSessionCookie_AppendsCookie()
+    {
+        var context = new DefaultHttpContext();
+
+        SessionCookieHelper.SetSessionCookie(context.Response, "token", true);
+
+        Assert.IsTrue(context.Response.Headers.SetCookie.ToString().Contains("SessionId=token"));
+    }
+
+    [TestMethod]
+    public void RemoveSessionCookie_DeletesCookie()
+    {
+        var context = new DefaultHttpContext();
+        SessionCookieHelper.SetSessionCookie(context.Response, "abc", true);
+
+        SessionCookieHelper.RemoveSessionCookie(context.Response);
+
+        Assert.IsTrue(context.Response.Headers.SetCookie.ToString().Contains("SessionId=;"));
+    }
+}

--- a/MagentaTV.Tests/SessionDataTests.cs
+++ b/MagentaTV.Tests/SessionDataTests.cs
@@ -1,0 +1,60 @@
+using System;
+using MagentaTV.Services.Session;
+using MagentaTV.Models.Session;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class SessionDataTests
+{
+    [TestMethod]
+    public void UpdateActivity_SetsLastActivityAndActivates()
+    {
+        var session = new SessionData
+        {
+            SessionId = "1",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30),
+            Status = SessionStatus.Inactive
+        };
+
+        var before = session.LastActivity;
+        session.UpdateActivity();
+
+        Assert.IsTrue(session.LastActivity > before);
+        Assert.AreEqual(SessionStatus.Active, session.Status);
+    }
+
+    [TestMethod]
+    public void Expire_SetsStatusAndExpiresAt()
+    {
+        var session = new SessionData
+        {
+            SessionId = "1",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30)
+        };
+
+        session.Expire();
+
+        Assert.AreEqual(SessionStatus.Expired, session.Status);
+        Assert.IsTrue(session.ExpiresAt <= DateTime.UtcNow);
+    }
+
+    [TestMethod]
+    public void Revoke_SetsStatusToRevoked()
+    {
+        var session = new SessionData { SessionId = "1" };
+
+        session.Revoke();
+
+        Assert.AreEqual(SessionStatus.Revoked, session.Status);
+    }
+
+    [TestMethod]
+    public void IsInactive_ReturnsTrue_WhenTimeoutExceeded()
+    {
+        var session = new SessionData { LastActivity = DateTime.UtcNow.AddMinutes(-10) };
+
+        Assert.IsTrue(session.IsInactive(TimeSpan.FromMinutes(5)));
+    }
+}

--- a/MagentaTV.Tests/SessionExtensionsTests.cs
+++ b/MagentaTV.Tests/SessionExtensionsTests.cs
@@ -1,0 +1,53 @@
+using System;
+using MagentaTV.Extensions;
+using MagentaTV.Services.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class SessionExtensionsTests
+{
+    [TestMethod]
+    public void GetCurrentSession_ReturnsSession_WhenPresent()
+    {
+        var context = new DefaultHttpContext();
+        var session = new SessionData { SessionId = "1" };
+        context.Items["CurrentSession"] = session;
+
+        var result = context.GetCurrentSession();
+        Assert.AreSame(session, result);
+    }
+
+    [TestMethod]
+    public void GetCurrentUsername_ReturnsUsername_WhenPresent()
+    {
+        var context = new DefaultHttpContext();
+        context.Items["CurrentUsername"] = "user";
+
+        var result = context.GetCurrentUsername();
+        Assert.AreEqual("user", result);
+    }
+
+    [TestMethod]
+    public void IsAuthenticated_ReturnsTrue_ForActiveSession()
+    {
+        var context = new DefaultHttpContext();
+        var session = new SessionData
+        {
+            SessionId = "1",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+        };
+        context.Items["CurrentSession"] = session;
+
+        Assert.IsTrue(context.IsAuthenticated());
+    }
+
+    [TestMethod]
+    public void RequireSession_Throws_WhenNoSession()
+    {
+        var context = new DefaultHttpContext();
+        Assert.ThrowsException<UnauthorizedAccessException>(() => context.RequireSession());
+    }
+}

--- a/MagentaTV.Tests/SessionOptionsTests.cs
+++ b/MagentaTV.Tests/SessionOptionsTests.cs
@@ -1,0 +1,32 @@
+using System;
+using MagentaTV.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class SessionOptionsTests
+{
+    [TestMethod]
+    public void Validate_Throws_WhenDefaultGreaterThanMax()
+    {
+        var opts = new SessionOptions
+        {
+            DefaultDurationHours = 10,
+            MaxDurationHours = 5,
+            EncryptionKey = new string('x',32)
+        };
+
+        Assert.ThrowsException<ArgumentException>(() => opts.Validate());
+    }
+
+    [TestMethod]
+    public void GetEncryptionKey_ReturnsEnvVar_WhenSet()
+    {
+        Environment.SetEnvironmentVariable("SESSION_ENCRYPTION_KEY", "abcdef" + new string('x',26));
+        var opts = new SessionOptions { EncryptionKey = "ignore" };
+        var key = opts.GetEncryptionKey();
+        Assert.AreEqual("abcdef" + new string('x',26), key);
+        Environment.SetEnvironmentVariable("SESSION_ENCRYPTION_KEY", null);
+    }
+}

--- a/MagentaTV.Tests/TokenDataTests.cs
+++ b/MagentaTV.Tests/TokenDataTests.cs
@@ -1,0 +1,45 @@
+using System;
+using MagentaTV.Services.TokenStorage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class TokenDataTests
+{
+    [TestMethod]
+    public void IsExpired_ReturnsTrue_WhenPastDate()
+    {
+        var token = new TokenData
+        {
+            AccessToken = "abc",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(-1)
+        };
+
+        Assert.IsTrue(token.IsExpired);
+    }
+
+    [TestMethod]
+    public void IsValid_ReturnsTrue_WhenTokenNotExpired()
+    {
+        var token = new TokenData
+        {
+            AccessToken = "abc",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+        };
+
+        Assert.IsTrue(token.IsValid);
+    }
+
+    [TestMethod]
+    public void IsNearExpiry_ReturnsTrue_WhenLessThanFiveMinutes()
+    {
+        var token = new TokenData
+        {
+            AccessToken = "abc",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(4)
+        };
+
+        Assert.IsTrue(token.IsNearExpiry);
+    }
+}

--- a/MagentaTV.sln
+++ b/MagentaTV.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36127.28 d17.14
+VisualStudioVersion = 17.14.36127.28
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MagentaTV", "MagentaTV\MagentaTV.csproj", "{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}"
 EndProject
@@ -17,21 +17,55 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MagentaTV.Tests", "MagentaTV.Tests\MagentaTV.Tests.csproj", "{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Debug|x86.Build.0 = Debug|Any CPU
 		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|Any CPU.Build.0 = Release|Any CPU
-                {CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|Any CPU.Build.0 = Release|Any CPU
-        EndGlobalSection
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|x64.Build.0 = Release|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBBEB05A-5CE9-4157-BAE4-0AFC6334B870}.Release|x86.Build.0 = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|x64.Build.0 = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF30B1D7-5443-4FF3-8CAF-1F1A7C6AFAF7}.Release|x86.Build.0 = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|x64.Build.0 = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F8319BE-BDF4-4C92-9A40-0DEE7226A932}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a new `MagentaTV.Tests` MSTest project
- implement tests for token and session helpers
- update solution to include test project
- add more unit tests for configuration and extension helpers

## Testing
- `dotnet test MagentaTV.Tests/MagentaTV.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6843e0f3290c832687496872eb164d8d