### PR TITLE
Implement access tracking for tokens

### DIFF
--- a/MagentaTV.Tests/InMemoryTokenStorageTests.cs
+++ b/MagentaTV.Tests/InMemoryTokenStorageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using System.Reflection;
 using MagentaTV.Configuration;
 using MagentaTV.Services.TokenStorage;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -62,5 +63,50 @@ public sealed class InMemoryTokenStorageTests
         Assert.IsNull(result);
         Assert.AreEqual(1, storage.Metrics.Expirations);
         Assert.AreEqual(1, storage.Metrics.Misses);
+    }
+
+    [TestMethod]
+    public async Task LoadTokensAsync_UpdatesLastAccessAndAccessCount()
+    {
+        var options = Options.Create(new TokenStorageOptions { MaxTokenCount = 10 });
+        var storage = new InMemoryTokenStorage(new NullLogger<InMemoryTokenStorage>(), options);
+
+        await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddHours(1) });
+
+        var field = typeof(InMemoryTokenStorage).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)field.GetValue(storage)!;
+
+        dict.TryGetValue("1", out var beforeEntry);
+        var beforeAccess = beforeEntry.LastAccess;
+        var beforeCount = beforeEntry.AccessCount;
+
+        await Task.Delay(10);
+        _ = await storage.LoadTokensAsync("1");
+
+        dict.TryGetValue("1", out var afterEntry);
+        Assert.IsTrue(afterEntry.LastAccess > beforeAccess);
+        Assert.AreEqual(beforeCount + 1, afterEntry.AccessCount);
+    }
+
+    [TestMethod]
+    public async Task SaveTokensAsync_PreservesAccessCountWhenUpdating()
+    {
+        var options = Options.Create(new TokenStorageOptions { MaxTokenCount = 10 });
+        var storage = new InMemoryTokenStorage(new NullLogger<InMemoryTokenStorage>(), options);
+
+        await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddHours(1) });
+        _ = await storage.LoadTokensAsync("1");
+
+        var field = typeof(InMemoryTokenStorage).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)field.GetValue(storage)!;
+
+        dict.TryGetValue("1", out var beforeEntry);
+        var beforeCount = beforeEntry.AccessCount;
+
+        await storage.SaveTokensAsync("1", new TokenData { AccessToken = "b", ExpiresAt = DateTime.UtcNow.AddHours(2) });
+
+        dict.TryGetValue("1", out var afterEntry);
+        Assert.AreEqual(beforeCount + 1, afterEntry.AccessCount);
+        Assert.IsTrue(afterEntry.LastAccess >= beforeEntry.LastAccess);
     }
 }

--- a/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
+++ b/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
@@ -43,8 +43,14 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
     /// </summary>
     public Task SaveTokensAsync(string sessionId, TokenData tokens)
     {
-        var entry = new TokenEntry(tokens);
-        _tokens.AddOrUpdate(sessionId, entry, (_, _) => entry);
+        _tokens.AddOrUpdate(sessionId,
+            _ => new TokenEntry(tokens),
+            (_, existing) =>
+            {
+                existing.Data = tokens;
+                existing.UpdateAccess();
+                return existing;
+            });
 
         _logger.LogDebug(
             "Tokens saved in memory for session {SessionId}, user: {Username}, expires: {ExpiresAt}",

--- a/MagentaTV/Services/TokenStorage/TokenEntry.cs
+++ b/MagentaTV/Services/TokenStorage/TokenEntry.cs
@@ -7,6 +7,7 @@ public class TokenEntry
 {
     public TokenData Data { get; set; }
     public DateTime LastAccess { get; private set; }
+    public int AccessCount { get; private set; }
 
     public TokenEntry(TokenData data)
     {
@@ -17,5 +18,6 @@ public class TokenEntry
     public void UpdateAccess()
     {
         LastAccess = DateTime.UtcNow;
+        AccessCount++;
     }
 }


### PR DESCRIPTION
## Summary
- add `AccessCount` to `TokenEntry`
- track access when saving/loading tokens in memory
- add unit tests for new access tracking logic

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684410c0603c8326913d71d4f62cb647