### PR TITLE
Refactor token storage into dedicated components

### DIFF
--- a/MagentaTV.Tests/InMemoryTokenStorageTests.cs
+++ b/MagentaTV.Tests/InMemoryTokenStorageTests.cs
@@ -73,8 +73,10 @@ public sealed class InMemoryTokenStorageTests
 
         await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddHours(1) });
 
-        var field = typeof(InMemoryTokenStorage).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)field.GetValue(storage)!;
+        var cacheField = typeof(InMemoryTokenStorage).GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var cache = (TokenCache)cacheField.GetValue(storage)!;
+        var tokensField = typeof(TokenCache).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)tokensField.GetValue(cache)!;
 
         dict.TryGetValue("1", out var beforeEntry);
         var beforeAccess = beforeEntry.LastAccess;
@@ -97,8 +99,10 @@ public sealed class InMemoryTokenStorageTests
         await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddHours(1) });
         _ = await storage.LoadTokensAsync("1");
 
-        var field = typeof(InMemoryTokenStorage).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)field.GetValue(storage)!;
+        cacheField = typeof(InMemoryTokenStorage).GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        cache = (TokenCache)cacheField.GetValue(storage)!;
+        tokensField = typeof(TokenCache).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)tokensField.GetValue(cache)!;
 
         dict.TryGetValue("1", out var beforeEntry);
         var beforeCount = beforeEntry.AccessCount;

--- a/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
+++ b/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
@@ -1,6 +1,4 @@
 ﻿// MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
-using System.Collections.Concurrent;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MagentaTV.Configuration;
@@ -13,18 +11,17 @@ namespace MagentaTV.Services.TokenStorage;
 /// </summary>
 public class InMemoryTokenStorage : ITokenStorage, IDisposable
 {
-    private readonly ConcurrentDictionary<string, TokenEntry> _tokens = new();
+    private readonly TokenCache _cache;
     private readonly ILogger<InMemoryTokenStorage> _logger;
     private readonly TokenExpirationManager _expirationManager;
-    private readonly int _maxTokenCount;
     private readonly TokenStorageMetrics _metrics = new();
     private const string DefaultSessionId = "default";
 
     public InMemoryTokenStorage(ILogger<InMemoryTokenStorage> logger, IOptions<TokenStorageOptions> options)
     {
         _logger = logger;
-        _maxTokenCount = options.Value.MaxTokenCount;
-        _expirationManager = new TokenExpirationManager(_tokens, _metrics);
+        _cache = new TokenCache(options.Value.MaxTokenCount, _metrics, logger);
+        _expirationManager = new TokenExpirationManager(_cache, _metrics, logger);
         _logger.LogInformation("InMemoryTokenStorage initialized - tokens will not persist across restarts");
     }
 
@@ -43,20 +40,12 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
     /// </summary>
     public Task SaveTokensAsync(string sessionId, TokenData tokens)
     {
-        _tokens.AddOrUpdate(sessionId,
-            _ => new TokenEntry(tokens),
-            (_, existing) =>
-            {
-                existing.Data = tokens;
-                existing.UpdateAccess();
-                return existing;
-            });
+        _cache.Save(sessionId, tokens);
 
         _logger.LogDebug(
             "Tokens saved in memory for session {SessionId}, user: {Username}, expires: {ExpiresAt}",
             sessionId, tokens.Username, tokens.ExpiresAt);
 
-        EnforceLimit();
         return Task.CompletedTask;
     }
 
@@ -67,11 +56,11 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
 
     public Task<TokenData?> LoadTokensAsync(string sessionId)
     {
-        if (_tokens.TryGetValue(sessionId, out var entry))
+        if (_cache.TryGet(sessionId, out var entry))
         {
             if (entry.Data.IsExpired)
             {
-                _tokens.TryRemove(sessionId, out _);
+                _cache.TryRemove(sessionId, out _);
                 _metrics.IncrementExpiration();
                 _metrics.IncrementMiss();
                 _logger.LogDebug("Removed expired tokens for session {SessionId}", sessionId);
@@ -99,7 +88,7 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
 
     public Task ClearTokensAsync(string sessionId)
     {
-        _tokens.TryRemove(sessionId, out var removed);
+        _cache.TryRemove(sessionId, out var removed);
         var username = removed?.Data.Username;
         _logger.LogDebug(
             "Tokens cleared from memory for session {SessionId}, user: {Username}",
@@ -114,7 +103,7 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
 
     public Task<bool> HasValidTokensAsync(string sessionId)
     {
-        var hasValid = _tokens.TryGetValue(sessionId, out var entry) && entry.Data.IsValid;
+        var hasValid = _cache.TryGet(sessionId, out var entry) && entry.Data.IsValid;
         _logger.LogDebug("HasValidTokens check for {SessionId}: {HasValid}", sessionId, hasValid);
         return Task.FromResult(hasValid);
     }
@@ -124,7 +113,7 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
     /// </summary>
     public TokenStatus GetTokenStatus(string sessionId = DefaultSessionId)
     {
-        _tokens.TryGetValue(sessionId, out var entry);
+        _cache.TryGet(sessionId, out var entry);
         return new TokenStatus
         {
             HasTokens = entry != null,
@@ -133,32 +122,6 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
             ExpiresAt = entry?.Data.ExpiresAt,
             TimeToExpiry = entry?.Data.TimeToExpiry
         };
-    }
-
-    private void EnforceLimit()
-    {
-        if (_tokens.Count < _maxTokenCount)
-            return;
-
-        var removeCount = Math.Max(1, _maxTokenCount / 10);
-        var oldest = _tokens
-            .OrderBy(kvp => kvp.Value.LastAccess)
-            .Take(removeCount)
-            .Select(kvp => kvp.Key)
-            .ToList();
-
-        foreach (var key in oldest)
-        {
-            if (_tokens.TryRemove(key, out _))
-            {
-                _metrics.IncrementEviction();
-            }
-        }
-
-        if (oldest.Count > 0)
-        {
-            _logger.LogDebug("Evicted {Count} token entries due to limit", oldest.Count);
-        }
     }
 
     public void Dispose()

--- a/MagentaTV/Services/TokenStorage/TokenCache.cs
+++ b/MagentaTV/Services/TokenStorage/TokenCache.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace MagentaTV.Services.TokenStorage;
+
+/// <summary>
+/// In-memory cache for tokens with simple LRU eviction.
+/// </summary>
+public class TokenCache
+{
+    private readonly ConcurrentDictionary<string, TokenEntry> _tokens = new();
+    private readonly int _maxTokenCount;
+    private readonly ILogger<TokenCache>? _logger;
+    private readonly TokenStorageMetrics? _metrics;
+
+    public TokenCache(int maxTokenCount, TokenStorageMetrics? metrics = null, ILogger<TokenCache>? logger = null)
+    {
+        _maxTokenCount = maxTokenCount;
+        _metrics = metrics;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Adds or updates tokens for the given session.
+    /// </summary>
+    public void Save(string sessionId, TokenData tokens)
+    {
+        _tokens.AddOrUpdate(sessionId,
+            _ => new TokenEntry(tokens),
+            (_, existing) =>
+            {
+                existing.Data = tokens;
+                existing.UpdateAccess();
+                return existing;
+            });
+
+        EnforceLimit();
+    }
+
+    /// <summary>
+    /// Attempts to retrieve tokens for the session.
+    /// </summary>
+    public bool TryGet(string sessionId, out TokenEntry entry) => _tokens.TryGetValue(sessionId, out entry);
+
+    /// <summary>
+    /// Removes tokens for the given session.
+    /// </summary>
+    public bool TryRemove(string sessionId, out TokenEntry? removed) => _tokens.TryRemove(sessionId, out removed);
+
+    /// <summary>
+    /// Enumerates all entries. Intended for internal use.
+    /// </summary>
+    internal IEnumerable<KeyValuePair<string, TokenEntry>> Entries => _tokens.ToArray();
+
+    private void EnforceLimit()
+    {
+        if (_tokens.Count < _maxTokenCount)
+            return;
+
+        var removeCount = Math.Max(1, _maxTokenCount / 10);
+        var oldest = _tokens
+            .OrderBy(kvp => kvp.Value.LastAccess)
+            .Take(removeCount)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in oldest)
+        {
+            if (_tokens.TryRemove(key, out _))
+            {
+                _metrics?.IncrementEviction();
+            }
+        }
+
+        if (oldest.Count > 0)
+        {
+            _logger?.LogDebug("Evicted {Count} token entries due to limit", oldest.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TokenCache class to encapsulate dictionary operations and LRU eviction
- update TokenExpirationManager to use TokenCache
- refactor InMemoryTokenStorage to orchestrate components
- adjust unit tests for new structure

## Testing
- `dotnet test --no-build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6844132b971c83269d6a1774082b02ef