### PR TITLE
Ensure timers get disposed

### DIFF
--- a/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
+++ b/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
@@ -15,6 +15,7 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
     private readonly ILogger<InMemoryTokenStorage> _logger;
     private readonly TokenExpirationManager _expirationManager;
     private readonly TokenStorageMetrics _metrics = new();
+    private bool _disposed;
     private const string DefaultSessionId = "default";
 
     public InMemoryTokenStorage(ILogger<InMemoryTokenStorage> logger, IOptions<TokenStorageOptions> options)
@@ -126,7 +127,26 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
 
     public void Dispose()
     {
-        _expirationManager.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+        {
+            _expirationManager.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    ~InMemoryTokenStorage()
+    {
+        Dispose(false);
     }
 }
 

--- a/MagentaTV/Services/TokenStorage/TokenExpirationManager.cs
+++ b/MagentaTV/Services/TokenStorage/TokenExpirationManager.cs
@@ -13,6 +13,7 @@ public class TokenExpirationManager : IDisposable
     private readonly ILogger<TokenExpirationManager>? _logger;
     private readonly TokenStorageMetrics? _metrics;
     private readonly Timer _timer;
+    private bool _disposed;
 
     public TokenExpirationManager(
         TokenCache cache,
@@ -42,6 +43,25 @@ public class TokenExpirationManager : IDisposable
 
     public void Dispose()
     {
-        _timer.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+        {
+            _timer.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    ~TokenExpirationManager()
+    {
+        Dispose(false);
     }
 }


### PR DESCRIPTION
## Summary
- add disposal pattern for TokenExpirationManager
- dispose timer helper from InMemoryTokenStorage

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684414f909408326b938573be916c9b0