### PR TITLE
Add token cache cleanup tests

### DIFF
--- a/MagentaTV.Tests/InMemoryTokenStorageTests.cs
+++ b/MagentaTV.Tests/InMemoryTokenStorageTests.cs
@@ -60,7 +60,11 @@ public sealed class InMemoryTokenStorageTests
 
         var result = await storage.LoadTokensAsync("1");
 
+        var cacheField = typeof(InMemoryTokenStorage).GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var cache = (TokenCache)cacheField.GetValue(storage)!;
+
         Assert.IsNull(result);
+        Assert.IsFalse(cache.TryGet("1", out _));
         Assert.AreEqual(1, storage.Metrics.Expirations);
         Assert.AreEqual(1, storage.Metrics.Misses);
     }
@@ -99,10 +103,10 @@ public sealed class InMemoryTokenStorageTests
         await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddHours(1) });
         _ = await storage.LoadTokensAsync("1");
 
-        cacheField = typeof(InMemoryTokenStorage).GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        cache = (TokenCache)cacheField.GetValue(storage)!;
-        tokensField = typeof(TokenCache).GetField("_tokens", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)tokensField.GetValue(cache)!;
+        var cacheField = typeof(InMemoryTokenStorage).GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var cache = (TokenCache)cacheField.GetValue(storage)!;
+        var tokensField = typeof(TokenCache).GetField("_tokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = (System.Collections.Concurrent.ConcurrentDictionary<string, TokenEntry>)tokensField.GetValue(cache)!;
 
         dict.TryGetValue("1", out var beforeEntry);
         var beforeCount = beforeEntry.AccessCount;
@@ -112,5 +116,33 @@ public sealed class InMemoryTokenStorageTests
         dict.TryGetValue("1", out var afterEntry);
         Assert.AreEqual(beforeCount + 1, afterEntry.AccessCount);
         Assert.IsTrue(afterEntry.LastAccess >= beforeEntry.LastAccess);
+    }
+
+    [TestMethod]
+    public async Task MetricsCounters_AreUpdatedCorrectly()
+    {
+        var options = Options.Create(new TokenStorageOptions { MaxTokenCount = 5 });
+        var storage = new InMemoryTokenStorage(new NullLogger<InMemoryTokenStorage>(), options);
+
+        await storage.SaveTokensAsync("expired", new TokenData { AccessToken = "e", ExpiresAt = DateTime.UtcNow.AddMilliseconds(-1) });
+        await storage.SaveTokensAsync("1", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+        await storage.SaveTokensAsync("2", new TokenData { AccessToken = "b", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+
+        _ = await storage.LoadTokensAsync("expired");
+
+        await storage.SaveTokensAsync("3", new TokenData { AccessToken = "c", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+        await storage.SaveTokensAsync("4", new TokenData { AccessToken = "d", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+        await storage.SaveTokensAsync("5", new TokenData { AccessToken = "f", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+        await storage.SaveTokensAsync("6", new TokenData { AccessToken = "g", ExpiresAt = DateTime.UtcNow.AddMinutes(1) });
+
+        var hit = await storage.LoadTokensAsync("5");
+        var miss = await storage.LoadTokensAsync("missing");
+
+        Assert.IsNotNull(hit);
+        Assert.IsNull(miss);
+        Assert.AreEqual(1, storage.Metrics.Hits);
+        Assert.AreEqual(2, storage.Metrics.Misses);
+        Assert.AreEqual(2, storage.Metrics.Evictions);
+        Assert.AreEqual(1, storage.Metrics.Expirations);
     }
 }

--- a/MagentaTV.Tests/TokenExpirationManagerTests.cs
+++ b/MagentaTV.Tests/TokenExpirationManagerTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using MagentaTV.Services.TokenStorage;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class TokenExpirationManagerTests
+{
+    [TestMethod]
+    public void CleanupExpiredTokens_RemovesEntriesAndUpdatesMetrics()
+    {
+        var metrics = new TokenStorageMetrics();
+        var cache = new TokenCache(10, metrics, NullLogger<TokenCache>.Instance);
+        using var manager = new TokenExpirationManager(cache, metrics, NullLogger<TokenExpirationManager>.Instance);
+
+        cache.Save("expired", new TokenData { AccessToken = "a", ExpiresAt = DateTime.UtcNow.AddMilliseconds(-1) });
+        cache.Save("valid", new TokenData { AccessToken = "b", ExpiresAt = DateTime.UtcNow.AddMinutes(5) });
+
+        var method = typeof(TokenExpirationManager).GetMethod("CleanupExpiredTokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(manager, null);
+
+        Assert.IsFalse(cache.TryGet("expired", out _));
+        Assert.IsTrue(cache.TryGet("valid", out _));
+        Assert.AreEqual(1, metrics.Expirations);
+    }
+}

--- a/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
+++ b/MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
@@ -1,5 +1,6 @@
 ﻿// MagentaTV/Services/TokenStorage/InMemoryTokenStorage.cs
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MagentaTV.Configuration;
 
@@ -21,8 +22,8 @@ public class InMemoryTokenStorage : ITokenStorage, IDisposable
     public InMemoryTokenStorage(ILogger<InMemoryTokenStorage> logger, IOptions<TokenStorageOptions> options)
     {
         _logger = logger;
-        _cache = new TokenCache(options.Value.MaxTokenCount, _metrics, logger);
-        _expirationManager = new TokenExpirationManager(_cache, _metrics, logger);
+        _cache = new TokenCache(options.Value.MaxTokenCount, _metrics, NullLogger<TokenCache>.Instance);
+        _expirationManager = new TokenExpirationManager(_cache, _metrics, NullLogger<TokenExpirationManager>.Instance);
         _logger.LogInformation("InMemoryTokenStorage initialized - tokens will not persist across restarts");
     }
 


### PR DESCRIPTION
## Summary
- add test for TokenExpirationManager cleanup
- verify expired tokens are purged when loading
- check metrics counters after a sequence of operations
- make InMemoryTokenStorage use null loggers for internal components

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684417034eac83268803165008ed28ef