### PR TITLE
Implement bulk EPG endpoint

### DIFF
--- a/MagentaTV.Client/MagentaTvClient.cs
+++ b/MagentaTV.Client/MagentaTvClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Sockets;
@@ -65,6 +66,20 @@ public class MagentaTvClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<ApiResponse<List<EpgItemDto>>>()
                ?? new ApiResponse<List<EpgItemDto>> { Success = false, Message = "Invalid response" };
+    }
+
+    public async Task<ApiResponse<Dictionary<int, List<EpgItemDto>>>> GetEpgBulkAsync(IEnumerable<int> channelIds, DateTime? from = null, DateTime? to = null)
+    {
+        var idList = string.Join(",", channelIds);
+        var query = new List<string> { $"ids={idList}" };
+        if (from.HasValue) query.Add($"from={from:O}");
+        if (to.HasValue) query.Add($"to={to:O}");
+        var url = "magenta/epg/bulk?" + string.Join("&", query);
+
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ApiResponse<Dictionary<int, List<EpgItemDto>>>>()
+               ?? new ApiResponse<Dictionary<int, List<EpgItemDto>>> { Success = false, Message = "Invalid response" };
     }
 
     public async Task<ApiResponse<StreamUrlDto>> GetStreamUrlAsync(int channelId)

--- a/MagentaTV.Tests/GetBulkEpgQueryHandlerTests.cs
+++ b/MagentaTV.Tests/GetBulkEpgQueryHandlerTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MagentaTV.Application.Queries;
+using MagentaTV.Models;
+using MagentaTV.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class GetBulkEpgQueryHandlerTests
+{
+    private sealed class FakeMagenta : IMagenta
+    {
+        public Task<bool> LoginAsync(string username, string password) => throw new NotImplementedException();
+        public Task LogoutAsync(string sessionId) => throw new NotImplementedException();
+        public Task<List<ChannelDto>> GetChannelsAsync() => throw new NotImplementedException();
+        public Task<List<EpgItemDto>> GetEpgAsync(int channelId, DateTime? from = null, DateTime? to = null)
+        {
+            var epg = new List<EpgItemDto>
+            {
+                new() { Title = $"Ch{channelId}", StartTime = DateTime.UtcNow, EndTime = DateTime.UtcNow.AddHours(1), ScheduleId = channelId }
+            };
+            return Task.FromResult(epg);
+        }
+        public Task<string?> GetStreamUrlAsync(int channelId) => throw new NotImplementedException();
+        public Task<string?> GetCatchupStreamUrlAsync(long scheduleId) => throw new NotImplementedException();
+        public Task<string> GenerateM3UPlaylistAsync() => throw new NotImplementedException();
+        public string GenerateXmlTv(List<EpgItemDto> epg, int channelId) => throw new NotImplementedException();
+        public Task<TokenData?> RefreshTokensAsync(TokenData currentTokens) => throw new NotImplementedException();
+    }
+
+    [TestMethod]
+    public async Task Handle_ReturnsDictionaryWithResults()
+    {
+        var handler = new GetBulkEpgQueryHandler(new FakeMagenta(), NullLogger<GetBulkEpgQueryHandler>.Instance);
+        var query = new GetBulkEpgQuery { ChannelIds = new[] { 1, 2 } };
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        Assert.AreEqual(2, result.Data.Count);
+        Assert.IsTrue(result.Data.ContainsKey(1));
+        Assert.AreEqual(1, result.Data[1][0].ScheduleId);
+    }
+}

--- a/MagentaTV.Tests/MagentaControllerBulkTests.cs
+++ b/MagentaTV.Tests/MagentaControllerBulkTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MagentaTV.Application.Queries;
+using MagentaTV.Controllers;
+using MagentaTV.Models;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class MagentaControllerBulkTests
+{
+    private sealed class TestMediator : IMediator
+    {
+        private readonly ApiResponse<Dictionary<int, List<EpgItemDto>>> _response;
+        public TestMediator(ApiResponse<Dictionary<int, List<EpgItemDto>>> response) => _response = response;
+        public Task Publish(object notification, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification => Task.CompletedTask;
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult((TResponse)(object)_response);
+        }
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default) => Task.FromResult<object?>(_response);
+    }
+
+    [TestMethod]
+    public async Task GetEpgBulk_ReturnsOk()
+    {
+        var data = new Dictionary<int, List<EpgItemDto>> { { 1, new List<EpgItemDto>() } };
+        var response = ApiResponse<Dictionary<int, List<EpgItemDto>>>.SuccessResult(data);
+        var mediator = new TestMediator(response);
+        var controller = new MagentaController(mediator, NullLogger<MagentaController>.Instance);
+
+        var result = await controller.GetEpgBulk("1");
+
+        Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+        var ok = (OkObjectResult)result;
+        Assert.AreSame(response, ok.Value);
+    }
+}

--- a/MagentaTV/Application/Queries/GetBulkEpgQuery.cs
+++ b/MagentaTV/Application/Queries/GetBulkEpgQuery.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MagentaTV.Models;
+using MediatR;
+
+namespace MagentaTV.Application.Queries;
+
+public class GetBulkEpgQuery : IRequest<ApiResponse<Dictionary<int, List<EpgItemDto>>>>
+{
+    public IEnumerable<int> ChannelIds { get; set; } = Enumerable.Empty<int>();
+    public DateTime? From { get; set; }
+    public DateTime? To { get; set; }
+}

--- a/MagentaTV/Application/Queries/GetBulkEpgQueryHandler.cs
+++ b/MagentaTV/Application/Queries/GetBulkEpgQueryHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MagentaTV.Models;
+using MagentaTV.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace MagentaTV.Application.Queries;
+
+public class GetBulkEpgQueryHandler : IRequestHandler<GetBulkEpgQuery, ApiResponse<Dictionary<int, List<EpgItemDto>>>>
+{
+    private readonly IMagenta _magenta;
+    private readonly ILogger<GetBulkEpgQueryHandler> _logger;
+
+    public GetBulkEpgQueryHandler(IMagenta magenta, ILogger<GetBulkEpgQueryHandler> logger)
+    {
+        _magenta = magenta;
+        _logger = logger;
+    }
+
+    public async Task<ApiResponse<Dictionary<int, List<EpgItemDto>>>> Handle(GetBulkEpgQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var tasks = request.ChannelIds.Select(async id =>
+            {
+                var epg = await _magenta.GetEpgAsync(id, request.From, request.To);
+                return (id, epg);
+            });
+
+            var results = await Task.WhenAll(tasks);
+            var dict = results.ToDictionary(r => r.id, r => r.epg);
+
+            return ApiResponse<Dictionary<int, List<EpgItemDto>>>.SuccessResult(dict,
+                $"Retrieved EPG for {dict.Count} channels");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get bulk EPG");
+            return ApiResponse<Dictionary<int, List<EpgItemDto>>>.ErrorResult("Failed to get EPG");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GetBulkEpgQuery` and `GetBulkEpgQueryHandler`
- expose `GET /magenta/epg/bulk` endpoint
- extend client with `GetEpgBulkAsync`
- add tests for handler and controller

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68449f287df08326bcdd8e0d283b5af3