### PR TITLE
Add bulk channels query and endpoint

### DIFF
--- a/MagentaTV.Client/MagentaTvClient.cs
+++ b/MagentaTV.Client/MagentaTvClient.cs
@@ -54,6 +54,15 @@ public class MagentaTvClient
                ?? new ApiResponse<List<ChannelDto>> { Success = false, Message = "Invalid response" };
     }
 
+    public async Task<ApiResponse<List<ChannelDto>>> GetChannelsBulkAsync(IEnumerable<int> channelIds)
+    {
+        var idList = string.Join(',', channelIds);
+        var response = await _httpClient.GetAsync($"magenta/channels/bulk?ids={idList}");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ApiResponse<List<ChannelDto>>>()
+               ?? new ApiResponse<List<ChannelDto>> { Success = false, Message = "Invalid response" };
+    }
+
     public async Task<ApiResponse<List<EpgItemDto>>> GetEpgAsync(int channelId, DateTime? from = null, DateTime? to = null)
     {
         var url = $"magenta/epg/{channelId}";

--- a/MagentaTV.Tests/GetChannelsBulkQueryHandlerTests.cs
+++ b/MagentaTV.Tests/GetChannelsBulkQueryHandlerTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MagentaTV.Application.Queries;
+using MagentaTV.Models;
+using MagentaTV.Services.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class GetChannelsBulkQueryHandlerTests
+{
+    private sealed class FakeChannelService : IChannelService
+    {
+        public List<ChannelDto> Channels { get; set; } = new();
+        public Task<List<ChannelDto>> GetChannelsAsync() => Task.FromResult(Channels);
+        public Task<string> GenerateM3UPlaylistAsync() => throw new System.NotImplementedException();
+    }
+
+    [TestMethod]
+    public async Task Handle_FiltersChannelsById()
+    {
+        var service = new FakeChannelService
+        {
+            Channels = new List<ChannelDto>
+            {
+                new() { ChannelId = 1, Name = "One" },
+                new() { ChannelId = 2, Name = "Two" },
+                new() { ChannelId = 3, Name = "Three" }
+            }
+        };
+
+        var handler = new GetChannelsBulkQueryHandler(service, NullLogger<GetChannelsBulkQueryHandler>.Instance);
+        var query = new GetChannelsBulkQuery { ChannelIds = new[] { 1, 3 } };
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.Data);
+        CollectionAssert.AreEqual(new[] { 1, 3 }, result.Data.Select(c => c.ChannelId).ToList());
+    }
+}

--- a/MagentaTV.Tests/MagentaControllerChannelsBulkTests.cs
+++ b/MagentaTV.Tests/MagentaControllerChannelsBulkTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MagentaTV.Application.Queries;
+using MagentaTV.Controllers;
+using MagentaTV.Models;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MagentaTV.Tests;
+
+[TestClass]
+public sealed class MagentaControllerChannelsBulkTests
+{
+    private sealed class TestMediator : IMediator
+    {
+        private readonly ApiResponse<List<ChannelDto>> _response;
+        public TestMediator(ApiResponse<List<ChannelDto>> response) => _response = response;
+        public Task Publish(object notification, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification => Task.CompletedTask;
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult((TResponse)(object)_response);
+        }
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default) => Task.FromResult<object?>(_response);
+    }
+
+    [TestMethod]
+    public async Task GetChannelsBulk_ReturnsOk()
+    {
+        var data = new List<ChannelDto> { new() { ChannelId = 1, Name = "Ch" } };
+        var response = ApiResponse<List<ChannelDto>>.SuccessResult(data);
+        var mediator = new TestMediator(response);
+        var controller = new MagentaController(mediator, NullLogger<MagentaController>.Instance);
+
+        var result = await controller.GetChannelsBulk("1");
+
+        Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+        var ok = (OkObjectResult)result;
+        Assert.AreSame(response, ok.Value);
+    }
+}

--- a/MagentaTV/Application/Queries/GetChannelsBulkQuery.cs
+++ b/MagentaTV/Application/Queries/GetChannelsBulkQuery.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using MagentaTV.Models;
+using MagentaTV.Services.Channels;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace MagentaTV.Application.Queries;
+
+public class GetChannelsBulkQuery : IRequest<ApiResponse<List<ChannelDto>>>
+{
+    public IEnumerable<int> ChannelIds { get; set; } = Enumerable.Empty<int>();
+}
+
+public class GetChannelsBulkQueryHandler : IRequestHandler<GetChannelsBulkQuery, ApiResponse<List<ChannelDto>>>
+{
+    private readonly IChannelService _channelService;
+    private readonly ILogger<GetChannelsBulkQueryHandler> _logger;
+
+    public GetChannelsBulkQueryHandler(IChannelService channelService, ILogger<GetChannelsBulkQueryHandler> logger)
+    {
+        _channelService = channelService;
+        _logger = logger;
+    }
+
+    public async Task<ApiResponse<List<ChannelDto>>> Handle(GetChannelsBulkQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var channels = await _channelService.GetChannelsAsync();
+            var filtered = channels.Where(c => request.ChannelIds.Contains(c.ChannelId)).ToList();
+            return ApiResponse<List<ChannelDto>>.SuccessResult(filtered, $"Found {filtered.Count} channels");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get channels");
+            return ApiResponse<List<ChannelDto>>.ErrorResult("Failed to get channels");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GetChannelsBulkQuery` with handler for filtering channels by ID
- expose `/magenta/channels/bulk` endpoint in `MagentaController`
- add client method `GetChannelsBulkAsync`
- create tests for the query handler and controller

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a04599d88326912cd55c5842ce4c